### PR TITLE
Update sidebar scrollbars to match the Kroxitrade panel style

### DIFF
--- a/components/Layout.svelte
+++ b/components/Layout.svelte
@@ -455,6 +455,30 @@
     padding: 12px 10px 10px;
     background-color: $poe-black;
     box-sizing: border-box;
+    scrollbar-width: thin;
+    scrollbar-color: rgba($gold, 0.22) rgba($white, 0.04);
+  }
+
+  main::-webkit-scrollbar {
+    width: 7px;
+  }
+
+  main::-webkit-scrollbar-track {
+    background: rgba($white, 0.04);
+  }
+
+  main::-webkit-scrollbar-thumb {
+    background: rgba($gold, 0.22);
+    border-radius: 999px;
+    border: 1px solid rgba($black, 0.45);
+  }
+
+  main::-webkit-scrollbar-thumb:hover {
+    background: rgba($gold, 0.34);
+  }
+
+  main::-webkit-scrollbar-corner {
+    background: transparent;
   }
 
   .floating-restore-btn {

--- a/lib/styles/base.scss
+++ b/lib/styles/base.scss
@@ -102,12 +102,33 @@
 }
 
 /* Scrollbar styling */
-#better-trading-container *::-webkit-scrollbar {
-  width: 6px;
+#kroxitrade-container,
+#kroxitrade-container * {
+  scrollbar-width: thin;
+  scrollbar-color: rgba($gold, 0.24) rgba($white, 0.03);
 }
-#better-trading-container *::-webkit-scrollbar-thumb {
-  background: #3a3a5a;
-  border-radius: 3px;
+
+#kroxitrade-container *::-webkit-scrollbar {
+  width: 7px;
+  height: 7px;
+}
+
+#kroxitrade-container *::-webkit-scrollbar-track {
+  background: rgba($white, 0.03);
+}
+
+#kroxitrade-container *::-webkit-scrollbar-thumb {
+  background: rgba($gold, 0.24);
+  border-radius: 999px;
+  border: 1px solid rgba($black, 0.35);
+}
+
+#kroxitrade-container *::-webkit-scrollbar-thumb:hover {
+  background: rgba($gold, 0.36);
+}
+
+#kroxitrade-container *::-webkit-scrollbar-corner {
+  background: transparent;
 }
 
 .flash-messages {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kroxitrade",
   "displayName": "Kroxitrade",
-  "version": "1.0.21",
+  "version": "1.0.23",
   "license": "MIT",
   "description": "A browser extension that enhances the Path of Exile trade site with bookmarks, history and result tools.",
   "author": "JaViJeC",


### PR DESCRIPTION
## Summary
- restyle sidebar scrollbars to use Kroxitrade's dark/gold palette instead of the browser default white appearance
- apply consistent scrollbar styling in both the injected base styles and the sidebar `main` container
- include the version bump to `1.0.23`

## Testing
- Not run (not requested)