### PR TITLE
Add observer retry cap and stale cache fallback

### DIFF
--- a/lib/services/item-results.ts
+++ b/lib/services/item-results.ts
@@ -363,6 +363,9 @@ export class ItemResultsService {
   }
 
   private observerTimer: ReturnType<typeof setTimeout> | null = null;
+  private observerRetries = 0;
+  private readonly OBSERVER_MAX_RETRIES = 10;
+  private readonly OBSERVER_RETRY_DELAY = 2000;
 
   private startObserving() {
     const observer = new MutationObserver((mutations) => {
@@ -372,15 +375,23 @@ export class ItemResultsService {
 
     const target = document.querySelector(".search-results, .resultset, .results");
     if (target) {
+      this.observerRetries = 0;
       observer.observe(target, { childList: true, subtree: true });
       this.enhanceResults();
-    } else {
-      // Fallback: observe body but keep trying to find the specific container
+    } else if (this.observerRetries < this.OBSERVER_MAX_RETRIES) {
+      // Fallback: observe body but keep trying to find the specific container.
+      // Cap retries so we don't poll forever if the page never renders results.
+      this.observerRetries++;
       observer.observe(document.body, { childList: true, subtree: true });
       setTimeout(() => {
         observer.disconnect();
         this.startObserving();
-      }, 2000);
+      }, this.OBSERVER_RETRY_DELAY);
+    } else {
+      emitPageDebug("observer-give-up", {
+        retries: this.observerRetries,
+        reason: "max-retries-reached"
+      });
     }
   }
 

--- a/lib/services/poe-ninja.ts
+++ b/lib/services/poe-ninja.ts
@@ -64,12 +64,25 @@ export class PoeNinjaService {
   }
 
   async fetchFreshChaosRatiosFor(league: string): Promise<PoeNinjaCurrenciesRatios> {
-    await storageService.deleteValue(RATIOS_CACHE_KEY, league);
+    // Stale-while-revalidate: keep the previous cache entry so we can fall
+    // back to it if the network request fails. Previously the cache was
+    // deleted up front, leaving no fallback when poe.ninja was unreachable.
+    const stale = await storageService.getStaleValue<PoeNinjaCurrenciesRatios>(RATIOS_CACHE_KEY, league);
 
-    const ratios = await this.requestChaosRatiosFor(league);
-    await storageService.setEphemeralValue(RATIOS_CACHE_KEY, ratios, dateDelta(RATIOS_CACHE_DURATION), league);
-
-    return ratios;
+    try {
+      const ratios = await this.requestChaosRatiosFor(league);
+      await storageService.setEphemeralValue(RATIOS_CACHE_KEY, ratios, dateDelta(RATIOS_CACHE_DURATION), league);
+      return ratios;
+    } catch (error) {
+      if (stale && Object.keys(stale).length > 0) {
+        emitPageDebug("poe-ninja-stale-fallback", {
+          league,
+          entries: Object.keys(stale).length
+        });
+        return stale;
+      }
+      throw error;
+    }
   }
 
   private async requestChaosRatiosFor(league: string): Promise<PoeNinjaCurrenciesRatios> {

--- a/lib/services/storage.ts
+++ b/lib/services/storage.ts
@@ -38,6 +38,11 @@ export class StorageService {
     return value;
   }
 
+  async getStaleValue<T>(key: string, league: string | null = null): Promise<T | null> {
+    const payload = await this.read(this.formatKey(key, league));
+    return payload ? (payload.value as T) : null;
+  }
+
   private formatKey(key: string, league: string | null) {
     return (league ? `${key}--${league}` : key).toLowerCase();
   }


### PR DESCRIPTION
## Summary

Two robustness fixes that prevent real user-facing failures: an unbounded retry loop on the results observer, and no currency ratios when poe.ninja is unreachable.

> **Depends on #30** — this branch is built on top of `fix/typecheck-dead-code-logs` to inherit the type-clean base and the `typecheck` script. Merge #30 first; the relevant diff for review here is the 3 files below.

## Changes

### 🔁 #8 — Cap MutationObserver retries

**`lib/services/item-results.ts`**

When the results container (`.search-results`) wasn't found, the fallback path observed `document.body` and recursively retried via `setTimeout` **every 2 seconds forever**. On pages that never render a results list (e.g. an error page, a layout change), this leaked CPU indefinitely.

**Fix:** added a retry counter capped at `OBSERVER_MAX_RETRIES = 10` (≈20s total). The counter resets to 0 once the real container is found. When giving up, a `page-debug` event is emitted so the state is observable.

```ts
private observerRetries = 0;
private readonly OBSERVER_MAX_RETRIES = 10;
private readonly OBSERVER_RETRY_DELAY = 2000;
```

### 🔄 #9 — Stale-while-revalidate for poe.ninja

**`lib/services/poe-ninja.ts`** + **`lib/services/storage.ts`**

`fetchFreshChaosRatiosFor()` deleted the cache entry **before** requesting fresh ratios. If poe.ninja was unreachable (network error, 429, 500), there was no fallback — the extension had no ratios until the next navigation triggered a successful fetch.

**Fix:** keep the previous entry and serve it as a **stale fallback** if the network request throws. The error only propagates when there is no stale cache at all.

```ts
const stale = await storageService.getStaleValue(...)
try {
  const ratios = await this.requestChaosRatiosFor(league);
  // ... persist fresh
  return ratios;
} catch (error) {
  if (stale && Object.keys(stale).length > 0) {
    emitPageDebug("poe-ninja-stale-fallback", ...)
    return stale;
  }
  throw error;
}
```

Added `StorageService.getStaleValue()` — reads a cache entry **ignoring** its expiration timestamp, used only by the SWR fallback.

## Verification

- `npm run typecheck` → ✅ exit 0
- `npm run build:chrome` → ✅ exit 0 (1.15 MB)

## Files changed

```
 lib/services/item-results.ts | 17 ++++++++++++++---
 lib/services/poe-ninja.ts    | 23 ++++++++++++++++++-----
 lib/services/storage.ts      |  5 +++++
 3 files changed, 37 insertions(+), 8 deletions(-)
```

🤖 Generated with [ZCode](https://zcode.dev)