### PR TITLE
[codex] Disable CoE copy for unsupported modifier slots

### DIFF
--- a/lib/data/whats-new.ts
+++ b/lib/data/whats-new.ts
@@ -43,6 +43,11 @@ const version111Items: WhatsNewItem[] = [
       "The CoE action button is now a centered 30px square so it aligns cleanly with the result row controls."
   },
   {
+    title: "Craft of Exile copy avoids unsupported modifier slots",
+    description:
+      "Items with Prefix/Suffix Modifier allowed affixes now show a greyed CoE button with an explanation, while Copy for PoB keeps working."
+  },
+  {
     title: "Version-specific settings are clearer",
     description:
       "PoE1 and PoE2 can keep separate result-tool preferences where that matters, and PoE2-only tools stay hidden on PoE1."

--- a/lib/services/item-results.ts
+++ b/lib/services/item-results.ts
@@ -10,7 +10,8 @@ import coeButtonImage from "../../assets/coe-button.webp?inline";
 import { copyItemForPob } from "../utilities/copy-item-for-pob";
 import {
   buildCraftOfExileText,
-  copyTextSynchronously
+  copyTextSynchronously,
+  hasUnsupportedCraftOfExileMod
 } from "../utilities/copy-item-for-craft-of-exile";
 import { flashMessages } from "./flash";
 import { experimentalSettings } from "./experimental";
@@ -72,6 +73,7 @@ export class ItemResultsService {
     ) {
       event.preventDefault();
       event.stopImmediatePropagation();
+      if (coeButton.getAttribute("aria-disabled") === "true") return;
 
       const row = coeButton.closest<HTMLElement>(".row, .result-item");
       const text = row ? buildCraftOfExileText(row) : null;
@@ -527,6 +529,7 @@ export class ItemResultsService {
     }
 
     if (button) {
+      this.syncCoeButtonUnsupportedState(button, row);
       if (searchByButton) this.positionCoeButton(button, searchByButton);
       return;
     }
@@ -534,8 +537,8 @@ export class ItemResultsService {
     button = document.createElement("button");
     button.type = "button";
     button.className = "bt-copy-coe";
-    button.title = "Copy for Craft of Exile";
     button.setAttribute("aria-label", "Copy for Craft of Exile");
+    this.syncCoeButtonUnsupportedState(button, row);
     
     const image = document.createElement("img");
     image.src = coeButtonImage;
@@ -548,6 +551,15 @@ export class ItemResultsService {
     } else {
       left.appendChild(button);
     }
+  }
+
+  private syncCoeButtonUnsupportedState(button: HTMLButtonElement, row: HTMLElement) {
+    const unsupported = hasUnsupportedCraftOfExileMod(row);
+    button.classList.toggle("bt-copy-coe--disabled", unsupported);
+    button.setAttribute("aria-disabled", unsupported ? "true" : "false");
+    button.title = unsupported
+      ? "Craft of Exile can't import this item yet (Prefix/Suffix Modifier mods)."
+      : "Copy for Craft of Exile";
   }
 
   private positionCoeButton(button: HTMLButtonElement, searchByButton: HTMLButtonElement) {

--- a/lib/styles/enhancements.scss
+++ b/lib/styles/enhancements.scss
@@ -72,6 +72,12 @@ body.bt-dev-poe2-copy-visible .row:hover > .left > button.copy {
 
 }
 
+.row > .left > button.bt-copy-coe.bt-copy-coe--disabled {
+  cursor: not-allowed;
+  filter: grayscale(1);
+  opacity: 0.42;
+}
+
 body.bt-dev-coe-visible .row:hover > .left > button.bt-copy-coe,
 body.bt-dev-result-actions-visible.bt-dev-coe-visible .row > .left > button.bt-copy-coe {
   display: inline-flex;

--- a/lib/utilities/copy-item-for-craft-of-exile.ts
+++ b/lib/utilities/copy-item-for-craft-of-exile.ts
@@ -1,4 +1,6 @@
 const SEPARATOR = "--------";
+const UNSUPPORTED_CRAFT_OF_EXILE_MOD_PATTERN =
+  /[+\-]\s*\d+\s+(?:Prefix|Suffix)\s+Modifiers?\s+allowed/i;
 
 const readNumber = (popup: HTMLElement, selector: string) => {
   const text = popup.querySelector<HTMLElement>(selector)?.textContent || "";
@@ -63,6 +65,11 @@ export const buildCraftOfExileText = (row: HTMLElement): string | null => {
   if (corrupted) sections.push(["Corrupted"]);
 
   return sections.map((section) => section.join("\n")).join(`\n${SEPARATOR}\n`);
+};
+
+export const hasUnsupportedCraftOfExileMod = (row: HTMLElement): boolean => {
+  const content = row.querySelector<HTMLElement>(".item-popup__content") || row;
+  return UNSUPPORTED_CRAFT_OF_EXILE_MOD_PATTERN.test(content.textContent || "");
 };
 
 export const copyTextSynchronously = (text: string): boolean => {


### PR DESCRIPTION
## Summary
- Disable the Craft of Exile copy button on items with `+/- Prefix/Suffix Modifier allowed` affixes.
- Keep the button hoverable with a tooltip explaining why CoE copy is unavailable.
- Leave Copy for Path of Building unaffected.
- Add the fix to the 1.1.1 What's New notes.

## Root cause
Craft of Exile cannot import these modifier-slot affixes yet, so exporting them creates a broken CoE import.

## Validation
- npm run typecheck
- npm run build:chrome
