### PR TITLE
Release v1.1.7

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -3,4 +3,4 @@
 1. Update `package.json` version, then run `npm run release:check`. It confirms the active `1.x` What's New section covers every user-facing change in every language and writes the release changelog.
 2. Run `npm run release:prepare` from `main`. It validates What's New, creates `release-vX.Y.Z`, commits current changes, runs `npm run package`, creates Chrome, Firefox, and source ZIP assets, pushes the branch, and opens an upstream PR.
 3. Merge the upstream PR.
-4. Run `npm run release:publish -- release-vX.Y.Z`. It verifies the upstream PR merged, then creates matching GitHub releases in `javijec/PoeTradePlus` and `KroxiLabs/Kroxitrade` with all three assets and the full What's New changelog.
+4. Run `npm run release:publish -- release-vX.Y.Z`. It verifies the upstream PR merged, creates matching GitHub releases in `javijec/PoeTradePlus` and `KroxiLabs/Kroxitrade` with all three assets and the full What's New changelog, then deletes the local and origin release branch.

--- a/components/BookmarkFolder.svelte
+++ b/components/BookmarkFolder.svelte
@@ -25,8 +25,7 @@
     BookmarksTradeStruct
   } from "../lib/types/bookmarks"
   import { copyToClipboard } from "../lib/utilities/copy-to-clipboard"
-  import { resolveTradeLeague, resolveTradeUrl } from "../lib/utilities/trade-url"
-  import { formatLeagueLabel } from "../lib/utilities/league"
+  import { resolveTradeUrl } from "../lib/utilities/trade-url"
   import Button from "./Button.svelte"
   import ConfirmDialog from "./ConfirmDialog.svelte"
   import FolderActionsMenu from "./FolderActionsMenu.svelte"
@@ -153,15 +152,6 @@
   onDestroy(() => {
     unsubscribeBookmarksChange()
   })
-
-  const formatTradeMeta = (trade: BookmarksTradeStruct) => {
-    const meta: string[] = []
-    const league = resolveTradeLeague(trade.location.league)
-
-    meta.push(formatLeagueLabel(league))
-
-    return meta.join(translate($languageStore, "folder.metaSeparator"))
-  }
 
   const normalizeCategoryTitle = (title: string) => title.trim()
 
@@ -900,7 +890,6 @@
                         <div class="trade-actions trade-actions--compact">
                           <TradeActionsMenu
                             {trade}
-                            compactText={formatTradeMeta(trade)}
                             onEdit={() => void startEditingTrade(trade)}
                             onReplace={() => void replaceSearchWithCurrent(trade)}
                             onCopy={() => copyTrade(trade)}
@@ -916,23 +905,20 @@
                       {/if}
                     </div>
                     {#if !$settings.compactActionsMenu}
-                      <div class="trade-bottom">
-                        <div class="trade-meta">{formatTradeMeta(trade)}</div>
-                        <div class="trade-actions">
-                          <TradeActionsMenu
-                            {trade}
-                            onEdit={() => void startEditingTrade(trade)}
-                            onReplace={() => void replaceSearchWithCurrent(trade)}
-                            onCopy={() => copyTrade(trade)}
-                            onOpenLive={() => void openTradeLive(trade)}
-                            onToggle={() => void toggleTrade(trade)}
-                            onDelete={() => requestTradeDelete(trade)}
-                            categoriesEnabled={$settings.bookmarkCategoriesEnabled}
-                            {categoryOptions}
-                            selectedCategoryId={categoryIdForTrade(trade)}
-                            onCategorySelect={(categoryId) => void selectTradeCategory(trade, categoryId)}
-                            onCategoryCreate={(title) => void createCategoryForTrade(trade, title)} />
-                        </div>
+                      <div class="trade-actions">
+                        <TradeActionsMenu
+                          {trade}
+                          onEdit={() => void startEditingTrade(trade)}
+                          onReplace={() => void replaceSearchWithCurrent(trade)}
+                          onCopy={() => copyTrade(trade)}
+                          onOpenLive={() => void openTradeLive(trade)}
+                          onToggle={() => void toggleTrade(trade)}
+                          onDelete={() => requestTradeDelete(trade)}
+                          categoriesEnabled={$settings.bookmarkCategoriesEnabled}
+                          {categoryOptions}
+                          selectedCategoryId={categoryIdForTrade(trade)}
+                          onCategorySelect={(categoryId) => void selectTradeCategory(trade, categoryId)}
+                          onCategoryCreate={(title) => void createCategoryForTrade(trade, title)} />
                       </div>
                     {/if}
                   </div>
@@ -1440,14 +1426,6 @@
     gap: 8px;
   }
 
-  .trade-bottom {
-    display: flex;
-    align-items: center;
-    justify-content: flex-start;
-    gap: 8px;
-    width: 100%;
-  }
-
   .trade-copy {
     min-width: 0;
     display: flex;
@@ -1466,18 +1444,6 @@
     text-overflow: ellipsis;
     white-space: nowrap;
     display: block;
-  }
-
-  .trade-meta {
-    min-width: 0;
-    flex: 1;
-    font-size: calc(10px * var(--bt-text-scale, 1));
-    line-height: 1.2;
-    color: rgba($gold-alt, 0.52);
-    letter-spacing: 0.03em;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
   }
 
   .trade-actions {

--- a/components/BookmarkFolder.svelte
+++ b/components/BookmarkFolder.svelte
@@ -344,7 +344,7 @@
   }
 
   const copyTrade = (trade: BookmarksTradeStruct) => {
-    const url = resolveTradeUrl(trade.location)
+    const url = resolveTradeUrl(trade.location, "", true)
     void copyToClipboard(url)
       .then(() => {
         flashMessages.success(
@@ -360,7 +360,7 @@
 
   const openTradeLive = async (trade: BookmarksTradeStruct) => {
     await openUrlInActiveTab(
-      resolveTradeUrl(trade.location, "/live")
+      resolveTradeUrl(trade.location, "/live", true)
     )
   }
 
@@ -487,7 +487,7 @@
   }
 
   const openTrade = async (trade: BookmarksTradeStruct) => {
-    await openUrlInActiveTab(resolveTradeUrl(trade.location))
+    await openUrlInActiveTab(resolveTradeUrl(trade.location, "", true))
   }
 
   const exportFolder = () => {

--- a/components/FinerFilters.svelte
+++ b/components/FinerFilters.svelte
@@ -3,6 +3,7 @@
   import { emitFinerFiltersAction } from "../lib/utilities/finer-filters-bridge";
   import {
     BUYOUT_CURRENCY_PRESETS,
+    clearBuyoutPrice,
     setBuyoutCurrencyPreset
   } from "../lib/utilities/buyout-currency";
   const listModifiers = [
@@ -52,6 +53,10 @@
   function handleBuyoutCurrency(currency: string) {
     setBuyoutCurrencyPreset(currency);
   }
+
+  function handleClearBuyoutPrice() {
+    clearBuyoutPrice();
+  }
 </script>
 
 <div class="finer-filters-container">
@@ -90,6 +95,12 @@
             {preset.label}
           </button>
         {/each}
+        <button
+          type="button"
+          class="action-btn buyout-clear"
+          onclick={handleClearBuyoutPrice}>
+          {translate($languageStore, "finer.clearBuyoutPrice")}
+        </button>
       </div>
     </div>
   {/if}
@@ -178,7 +189,7 @@
 
   .buyout-controls {
     display: grid;
-    grid-template-columns: repeat(3, minmax(0, 1fr));
+    grid-template-columns: repeat(4, minmax(0, 1fr));
     gap: 4px;
     margin-top: 2px;
   }
@@ -219,6 +230,11 @@
     &.buyout {
       background: rgba($gold, 0.18);
       &:hover { background: rgba($gold, 0.28); }
+    }
+
+    &.buyout-clear {
+      background: rgba(220, 53, 69, 0.3);
+      &:hover { background: rgba(220, 53, 69, 0.5); }
     }
   }
 </style>

--- a/contents/filter-panel.ts
+++ b/contents/filter-panel.ts
@@ -590,7 +590,10 @@ export const initFilterPanel = () => {
     e.stopPropagation()
 
     if (el.dataset.action === "krox-currency-preset") {
-      setBuyoutCurrencyPreset(el.dataset.currency || "Chaos Orb")
+      const preset = BUYOUT_CURRENCY_PRESETS.find(
+        ({ currency }) => currency === el.dataset.currency
+      )
+      setBuyoutCurrencyPreset(preset?.currency || "Chaos Orb")
       return
     }
 

--- a/contents/filter-panel.ts
+++ b/contents/filter-panel.ts
@@ -1,8 +1,10 @@
 import { isFinerFiltersActionMessage } from "~/lib/utilities/finer-filters-bridge"
 import {
   BUYOUT_CURRENCY_PRESETS,
+  clearBuyoutPrice,
   setBuyoutCurrencyPreset
 } from "~/lib/utilities/buyout-currency"
+import { translate, type AppLanguage } from "~/lib/services/i18n"
 
 export const initFilterPanel = () => {
   if ((window as any).__KROX_STARTED__) {
@@ -10,6 +12,22 @@ export const initFilterPanel = () => {
   }
 
   ;(window as any).__KROX_STARTED__ = true
+
+  const pageTranslation = (key: string) =>
+    translate(
+      (window.localStorage.getItem("bt-language") || "en") as AppLanguage,
+      key
+    )
+
+  const createBuyoutClearButton = () => {
+    const button = document.createElement("button")
+    button.type = "button"
+    button.className =
+      "krox-filter-preset__btn krox-filter-preset__btn--currency krox-filter-preset__btn--clear"
+    button.textContent = pageTranslation("finer.clearBuyoutPrice")
+    button.dataset.action = "krox-clear-buyout-price"
+    return button
+  }
 
   // ---------- helpers ----------
   const $ = (sel: string, root = document) => root.querySelector(sel)
@@ -491,7 +509,17 @@ export const initFilterPanel = () => {
       return
     }
 
-    if (!pane || existing) {
+    if (!pane) {
+      return
+    }
+
+    if (existing) {
+      const currencyRow = existing.querySelector<HTMLElement>(
+        ".krox-filter-preset--currency"
+      )
+      if (!currencyRow?.querySelector('[data-action="krox-clear-buyout-price"]')) {
+        currencyRow?.append(createBuyoutClearButton())
+      }
       return
     }
 
@@ -549,6 +577,8 @@ export const initFilterPanel = () => {
       currencyButton.dataset.currency = currency
       currencyRow.append(currencyButton)
     })
+
+    currencyRow.append(createBuyoutClearButton())
     list.appendChild(currencyRow)
 
     const firstExpandedGroup = pane.querySelector(".filter-group.expanded")
@@ -561,6 +591,11 @@ export const initFilterPanel = () => {
 
     if (el.dataset.action === "krox-currency-preset") {
       setBuyoutCurrencyPreset(el.dataset.currency || "Chaos Orb")
+      return
+    }
+
+    if (el.dataset.action === "krox-clear-buyout-price") {
+      clearBuyoutPrice()
       return
     }
 

--- a/lib/data/whats-new.ts
+++ b/lib/data/whats-new.ts
@@ -168,6 +168,17 @@ const version116Features: WhatsNewItem[] = [
   }
 ];
 
+const version117Features: WhatsNewItem[] = [
+  {
+    titleKey: "whatsNew.item.activeRealmBookmarksTitle",
+    descriptionKey: "whatsNew.item.activeRealmBookmarksDescription"
+  },
+  {
+    titleKey: "whatsNew.item.buyoutClearTitle",
+    descriptionKey: "whatsNew.item.buyoutClearDescription"
+  }
+];
+
 const version110Features: WhatsNewItem[] = [
   {
     title: "Settings are now easier to navigate",
@@ -258,9 +269,18 @@ const version110Changes: WhatsNewItem[] = [
 ];
 
 export const latestWhatsNew: WhatsNewEntry = {
-  version: "1.1.6",
-  date: "2026-07-07",
+  version: "1.1.7",
+  date: "2026-07-14",
   sections: [
+    {
+      title: "1.1.7",
+      groups: [
+        {
+          titleKey: "whatsNew.section.features",
+          items: version117Features
+        }
+      ]
+    },
     {
       title: "1.1.6",
       groups: [

--- a/lib/services/i18n/de.ts
+++ b/lib/services/i18n/de.ts
@@ -203,6 +203,12 @@ export const germanTranslations: Record<string, TranslationValue> = {
   "finer.spellWeapon": "Zauberwaffe",
   "finer.buyoutPrice": "Kaufpreis",
   "finer.clearBuyoutPrice": "Leeren",
+  "whatsNew.item.activeRealmBookmarksTitle": "Lesezeichen folgen dem aktiven Trade-Realm",
+  "whatsNew.item.activeRealmBookmarksDescription":
+    "Gespeicherte Suchen öffnen sich jetzt in Liga und Realm des aktiven Trade-Tabs; die gespeicherte Liga bleibt als Fallback erhalten.",
+  "whatsNew.item.buyoutClearTitle": "Schnellaktion zum Leeren des Kaufpreises",
+  "whatsNew.item.buyoutClearDescription":
+    "Schnellfilter-Voreinstellungen enthalten jetzt eine Schaltfläche zum Leeren, die den Kaufpreis auf Wert in Chaossphären setzt und mit unterstützten Trade-Website-Sprachen funktioniert.",
   "settings.onboardingTitle": "Tutorial",
   "settings.onboardingDescription":
     "Öffne das Schnell-Tutorial erneut, um die wichtigsten Aktionen und Tabs zu prüfen.",

--- a/lib/services/i18n/de.ts
+++ b/lib/services/i18n/de.ts
@@ -202,6 +202,7 @@ export const germanTranslations: Record<string, TranslationValue> = {
   "finer.attackWeapon": "Angriffswaffe",
   "finer.spellWeapon": "Zauberwaffe",
   "finer.buyoutPrice": "Kaufpreis",
+  "finer.clearBuyoutPrice": "Leeren",
   "settings.onboardingTitle": "Tutorial",
   "settings.onboardingDescription":
     "Öffne das Schnell-Tutorial erneut, um die wichtigsten Aktionen und Tabs zu prüfen.",

--- a/lib/services/i18n/en.ts
+++ b/lib/services/i18n/en.ts
@@ -435,5 +435,6 @@ export const englishTranslations: Record<string, TranslationValue> = {
   "finer.explicitResLife": "Explicit Res/Life",
   "finer.attackWeapon": "Attack Weapon",
   "finer.spellWeapon": "Spell Weapon",
-  "finer.buyoutPrice": "Buyout Price"
+  "finer.buyoutPrice": "Buyout Price",
+  "finer.clearBuyoutPrice": "Clear"
 } as Record<string, TranslationValue>

--- a/lib/services/i18n/en.ts
+++ b/lib/services/i18n/en.ts
@@ -436,5 +436,11 @@ export const englishTranslations: Record<string, TranslationValue> = {
   "finer.attackWeapon": "Attack Weapon",
   "finer.spellWeapon": "Spell Weapon",
   "finer.buyoutPrice": "Buyout Price",
-  "finer.clearBuyoutPrice": "Clear"
+  "finer.clearBuyoutPrice": "Clear",
+  "whatsNew.item.activeRealmBookmarksTitle": "Bookmarks follow active trade realm",
+  "whatsNew.item.activeRealmBookmarksDescription":
+    "Saved searches now open in the active trade tab's current league and realm, while keeping their saved league as a fallback.",
+  "whatsNew.item.buyoutClearTitle": "Clear Buyout Price shortcut",
+  "whatsNew.item.buyoutClearDescription":
+    "Quick Filter Presets now include a Clear button that resets Buyout Price to Chaos Orb Equivalent and works with supported trade-site languages."
 } as Record<string, TranslationValue>

--- a/lib/services/i18n/es.ts
+++ b/lib/services/i18n/es.ts
@@ -446,5 +446,11 @@ export const spanishTranslations: Record<string, TranslationValue> = {
   "finer.attackWeapon": "Arma de ataque",
   "finer.spellWeapon": "Arma de hechizos",
   "finer.buyoutPrice": "Precio de compra",
-  "finer.clearBuyoutPrice": "Limpiar"
+  "finer.clearBuyoutPrice": "Limpiar",
+  "whatsNew.item.activeRealmBookmarksTitle": "Los marcadores siguen el reino de trade activo",
+  "whatsNew.item.activeRealmBookmarksDescription":
+    "Las búsquedas guardadas ahora se abren en la liga y el reino actuales de la pestaña Trade activa, manteniendo la liga guardada como alternativa.",
+  "whatsNew.item.buyoutClearTitle": "Acceso rápido para limpiar el precio de compra",
+  "whatsNew.item.buyoutClearDescription":
+    "Los ajustes preestablecidos de filtro rápido ahora incluyen un botón Limpiar que restablece Precio de compra a Equivalente a Orbe de caos y funciona en los idiomas compatibles del sitio de trade."
 } as Record<string, TranslationValue>

--- a/lib/services/i18n/es.ts
+++ b/lib/services/i18n/es.ts
@@ -445,5 +445,6 @@ export const spanishTranslations: Record<string, TranslationValue> = {
   "finer.explicitResLife": "Res/Vida explícita",
   "finer.attackWeapon": "Arma de ataque",
   "finer.spellWeapon": "Arma de hechizos",
-  "finer.buyoutPrice": "Precio de compra"
+  "finer.buyoutPrice": "Precio de compra",
+  "finer.clearBuyoutPrice": "Limpiar"
 } as Record<string, TranslationValue>

--- a/lib/services/i18n/fr.ts
+++ b/lib/services/i18n/fr.ts
@@ -207,6 +207,7 @@ export const frenchTranslations: Record<string, TranslationValue> = {
   "finer.attackWeapon": "Arme d’attaque",
   "finer.spellWeapon": "Arme de sort",
   "finer.buyoutPrice": "Prix de rachat",
+  "finer.clearBuyoutPrice": "Effacer",
   "settings.onboardingTitle": "Tutoriel",
   "settings.onboardingDescription":
     "Rouvrez le guide rapide pour revoir les actions et onglets principaux.",

--- a/lib/services/i18n/fr.ts
+++ b/lib/services/i18n/fr.ts
@@ -208,6 +208,12 @@ export const frenchTranslations: Record<string, TranslationValue> = {
   "finer.spellWeapon": "Arme de sort",
   "finer.buyoutPrice": "Prix de rachat",
   "finer.clearBuyoutPrice": "Effacer",
+  "whatsNew.item.activeRealmBookmarksTitle": "Les favoris suivent le royaume trade actif",
+  "whatsNew.item.activeRealmBookmarksDescription":
+    "Les recherches enregistrées s’ouvrent maintenant dans la ligue et le royaume de l’onglet Trade actif, tout en conservant la ligue enregistrée comme solution de repli.",
+  "whatsNew.item.buyoutClearTitle": "Raccourci pour effacer le prix de rachat",
+  "whatsNew.item.buyoutClearDescription":
+    "Les préréglages de filtre rapide incluent désormais un bouton Effacer qui règle le prix de rachat sur Équivalent en orbes du chaos et fonctionne avec les langues prises en charge du site trade.",
   "settings.onboardingTitle": "Tutoriel",
   "settings.onboardingDescription":
     "Rouvrez le guide rapide pour revoir les actions et onglets principaux.",

--- a/lib/services/i18n/ja.ts
+++ b/lib/services/i18n/ja.ts
@@ -211,6 +211,12 @@ export const japaneseTranslations: Record<string, TranslationValue> = {
   "finer.spellWeapon": "スペル武器",
   "finer.buyoutPrice": "買い取り価格",
   "finer.clearBuyoutPrice": "クリア",
+  "whatsNew.item.activeRealmBookmarksTitle": "ブックマークがアクティブなTradeリーグとRealmに追従",
+  "whatsNew.item.activeRealmBookmarksDescription":
+    "保存した検索はアクティブなTradeタブの現在のリーグとRealmで開き、保存済みリーグはフォールバックとして保持されます。",
+  "whatsNew.item.buyoutClearTitle": "バイアウト価格をクリアするショートカット",
+  "whatsNew.item.buyoutClearDescription":
+    "クイックフィルタープリセットに、バイアウト価格をカオスオーブ同等物へ戻すクリアボタンが追加され、対応するTradeサイトの言語で動作します。",
   "settings.onboardingTitle": "チュートリアル",
   "settings.onboardingDescription":
     "主要な操作とタブを見直すために、クイックガイドをもう一度開きます。",

--- a/lib/services/i18n/ja.ts
+++ b/lib/services/i18n/ja.ts
@@ -210,6 +210,7 @@ export const japaneseTranslations: Record<string, TranslationValue> = {
   "finer.attackWeapon": "攻撃武器",
   "finer.spellWeapon": "スペル武器",
   "finer.buyoutPrice": "買い取り価格",
+  "finer.clearBuyoutPrice": "クリア",
   "settings.onboardingTitle": "チュートリアル",
   "settings.onboardingDescription":
     "主要な操作とタブを見直すために、クイックガイドをもう一度開きます。",

--- a/lib/services/i18n/ko.ts
+++ b/lib/services/i18n/ko.ts
@@ -207,6 +207,7 @@ export const koreanTranslations: Record<string, TranslationValue> = {
   "finer.attackWeapon": "공격 무기",
   "finer.spellWeapon": "주문 무기",
   "finer.buyoutPrice": "매입 가격",
+  "finer.clearBuyoutPrice": "지우기",
   "settings.onboardingTitle": "튜토리얼",
   "settings.onboardingDescription":
     "주요 작업과 탭을 다시 보려면 빠른 가이드를 다시 엽니다.",

--- a/lib/services/i18n/ko.ts
+++ b/lib/services/i18n/ko.ts
@@ -208,6 +208,12 @@ export const koreanTranslations: Record<string, TranslationValue> = {
   "finer.spellWeapon": "주문 무기",
   "finer.buyoutPrice": "매입 가격",
   "finer.clearBuyoutPrice": "지우기",
+  "whatsNew.item.activeRealmBookmarksTitle": "북마크가 활성 Trade 리그와 Realm을 따름",
+  "whatsNew.item.activeRealmBookmarksDescription":
+    "저장된 검색은 이제 활성 Trade 탭의 현재 리그와 Realm에서 열리며, 저장된 리그는 대체 값으로 유지됩니다.",
+  "whatsNew.item.buyoutClearTitle": "즉시 구매 가격 지우기 단축키",
+  "whatsNew.item.buyoutClearDescription":
+    "빠른 필터 프리셋에 즉시 구매 가격을 카오스 오브 등가물로 설정하는 지우기 버튼이 추가되었으며, 지원되는 Trade 사이트 언어에서 작동합니다.",
   "settings.onboardingTitle": "튜토리얼",
   "settings.onboardingDescription":
     "주요 작업과 탭을 다시 보려면 빠른 가이드를 다시 엽니다.",

--- a/lib/services/i18n/pt.ts
+++ b/lib/services/i18n/pt.ts
@@ -213,6 +213,7 @@ export const portugueseTranslations: Record<string, TranslationValue> = {
   "finer.attackWeapon": "Arma de ataque",
   "finer.spellWeapon": "Arma de feitiços",
   "finer.buyoutPrice": "Preço de compra",
+  "finer.clearBuyoutPrice": "Limpar",
   "settings.onboardingTitle": "Tutorial",
   "settings.onboardingDescription":
     "Abra o onboarding rápido de novo para rever as ações e abas principais.",

--- a/lib/services/i18n/pt.ts
+++ b/lib/services/i18n/pt.ts
@@ -214,6 +214,12 @@ export const portugueseTranslations: Record<string, TranslationValue> = {
   "finer.spellWeapon": "Arma de feitiços",
   "finer.buyoutPrice": "Preço de compra",
   "finer.clearBuyoutPrice": "Limpar",
+  "whatsNew.item.activeRealmBookmarksTitle": "Favoritos seguem o reino de trade ativo",
+  "whatsNew.item.activeRealmBookmarksDescription":
+    "Pesquisas salvas agora abrem na liga e no reino atuais da aba Trade ativa, mantendo a liga salva como alternativa.",
+  "whatsNew.item.buyoutClearTitle": "Atalho para limpar o preço de compra",
+  "whatsNew.item.buyoutClearDescription":
+    "Os presets de filtro rápido agora incluem um botão Limpar que redefine Preço de Compra para Equivalente a Orbe do Caos e funciona nos idiomas compatíveis do site de trade.",
   "settings.onboardingTitle": "Tutorial",
   "settings.onboardingDescription":
     "Abra o onboarding rápido de novo para rever as ações e abas principais.",

--- a/lib/services/i18n/ru.ts
+++ b/lib/services/i18n/ru.ts
@@ -200,6 +200,7 @@ export const russianTranslations: Record<string, TranslationValue> = {
   "finer.attackWeapon": "Оружие атаки",
   "finer.spellWeapon": "Оружие заклинаний",
   "finer.buyoutPrice": "Цена выкупа",
+  "finer.clearBuyoutPrice": "Очистить",
   "settings.onboardingTitle": "Обучение",
   "settings.onboardingDescription":
     "Снова откройте быстрый гид, чтобы еще раз посмотреть основные действия и вкладки.",

--- a/lib/services/i18n/ru.ts
+++ b/lib/services/i18n/ru.ts
@@ -201,6 +201,12 @@ export const russianTranslations: Record<string, TranslationValue> = {
   "finer.spellWeapon": "Оружие заклинаний",
   "finer.buyoutPrice": "Цена выкупа",
   "finer.clearBuyoutPrice": "Очистить",
+  "whatsNew.item.activeRealmBookmarksTitle": "Закладки следуют активному миру trade",
+  "whatsNew.item.activeRealmBookmarksDescription":
+    "Сохранённые поиски теперь открываются в текущей лиге и мире активной вкладки Trade, сохраняя сохранённую лигу как резервный вариант.",
+  "whatsNew.item.buyoutClearTitle": "Быстрая очистка цены выкупа",
+  "whatsNew.item.buyoutClearDescription":
+    "В быстрых фильтрах теперь есть кнопка «Очистить», которая переключает цену выкупа на эквивалент сферы хаоса и работает с поддерживаемыми языками сайта trade.",
   "settings.onboardingTitle": "Обучение",
   "settings.onboardingDescription":
     "Снова откройте быстрый гид, чтобы еще раз посмотреть основные действия и вкладки.",

--- a/lib/services/i18n/th.ts
+++ b/lib/services/i18n/th.ts
@@ -200,6 +200,12 @@ export const thaiTranslations: Record<string, TranslationValue> = {
   "finer.spellWeapon": "อาวุธเวท",
   "finer.buyoutPrice": "ราคาซื้อคืน",
   "finer.clearBuyoutPrice": "ล้าง",
+  "whatsNew.item.activeRealmBookmarksTitle": "บุ๊กมาร์กใช้ realm ของ trade ที่กำลังใช้งาน",
+  "whatsNew.item.activeRealmBookmarksDescription":
+    "การค้นหาที่บันทึกไว้จะเปิดด้วยลีกและ realm ปัจจุบันของแท็บ Trade ที่ใช้งานอยู่ โดยเก็บลีกที่บันทึกไว้เป็นทางเลือกสำรอง.",
+  "whatsNew.item.buyoutClearTitle": "ปุ่มล้างราคาซื้อทันที",
+  "whatsNew.item.buyoutClearDescription":
+    "พรีเซ็ตตัวกรองด่วนมีปุ่มล้างที่ตั้งราคาซื้อทันทีเป็นเทียบเป็น Chaos Orb และใช้ได้กับภาษาของเว็บไซต์ trade ที่รองรับ.",
   "settings.onboardingTitle": "บทช่วยสอน",
   "settings.onboardingDescription":
     "เปิดคู่มือเริ่มต้นอย่างรวดเร็วอีกครั้งเพื่อทบทวนการทำงานและแท็บหลัก",

--- a/lib/services/i18n/th.ts
+++ b/lib/services/i18n/th.ts
@@ -199,6 +199,7 @@ export const thaiTranslations: Record<string, TranslationValue> = {
   "finer.attackWeapon": "อาวุธโจมตี",
   "finer.spellWeapon": "อาวุธเวท",
   "finer.buyoutPrice": "ราคาซื้อคืน",
+  "finer.clearBuyoutPrice": "ล้าง",
   "settings.onboardingTitle": "บทช่วยสอน",
   "settings.onboardingDescription":
     "เปิดคู่มือเริ่มต้นอย่างรวดเร็วอีกครั้งเพื่อทบทวนการทำงานและแท็บหลัก",

--- a/lib/services/settings.ts
+++ b/lib/services/settings.ts
@@ -174,12 +174,14 @@ function publish() {
       `bt-quick-filters-placement-poe${activeVersion}`,
       currentSettings.quickFiltersPlacement
     )
+    window.localStorage.setItem("bt-language", currentSettings.language)
     window.dispatchEvent(
       new CustomEvent("poe-trade-plus:quick-filters-change", {
         detail: {
           key: quickFiltersStorageKey,
           value: currentSettings.showQuickFilters,
-          placement: currentSettings.quickFiltersPlacement
+          placement: currentSettings.quickFiltersPlacement,
+          language: currentSettings.language
         }
       })
     )

--- a/lib/styles/enhancements.scss
+++ b/lib/styles/enhancements.scss
@@ -548,7 +548,7 @@ body.bt-dev-result-actions-visible.bt-dev-wiki-visible .row > .left > button.bt-
 
 .krox-filter-preset--currency {
   grid-column: 1 / -1;
-  grid-template-columns: minmax(0, 1fr) repeat(3, minmax(54px, auto));
+  grid-template-columns: minmax(0, 1fr) repeat(4, minmax(54px, auto));
 }
 
 .krox-filter-preset__name {
@@ -590,6 +590,10 @@ body.bt-dev-result-actions-visible.bt-dev-wiki-visible .row > .left > button.bt-
   padding: 0 6px;
   background: rgba(168, 129, 73, 0.34);
   font-size: calc(11px * var(--bt-text-scale, 1));
+}
+
+.krox-filter-preset__btn--clear {
+  background: rgba(220, 53, 69, 0.34);
 }
 
 .krox-filter-preset__btn:hover,

--- a/lib/utilities/buyout-currency.ts
+++ b/lib/utilities/buyout-currency.ts
@@ -1,6 +1,12 @@
+export type BuyoutCurrency =
+  | "Chaos Orb"
+  | "Exalted Orb"
+  | "Divine Orb"
+  | "Chaos Orb Equivalent"
+
 export type BuyoutCurrencyPreset = {
   label: string
-  currency: string
+  currency: BuyoutCurrency
 }
 
 export const BUYOUT_CURRENCY_PRESETS: BuyoutCurrencyPreset[] = [
@@ -17,9 +23,67 @@ const setNativeInputValue = (input: HTMLInputElement, value: string) => {
   descriptor?.set?.call(input, value)
 }
 
-const findBuyoutCurrencySelect = () => {
-  return findBuyoutFilter()?.querySelector<HTMLElement>(".multiselect") || null
+const buyoutFilterTitles = [
+  "Buyout Price",
+  "Preço de Compra",
+  "Цена выкупа",
+  "ราคาขายทันที",
+  "Preis",
+  "Directe",
+  "Precio de compra",
+  "バイアウト価格",
+  "즉시 구매 가격"
+]
+
+const buyoutCurrencyLabels: Record<BuyoutCurrency, string[]> = {
+  "Chaos Orb Equivalent": [
+    "Chaos Orb Equivalent",
+    "Equivalente a Orbe do Caos",
+    "Эквивалент сферы хаоса",
+    "เทียบเป็น Chaos Orb",
+    "Wert in Chaossphären",
+    "Équivalent en orbes du chaos",
+    "Equivalente a Orbe de caos",
+    "カオスオーブ同等物",
+    "카오스 오브 등가물"
+  ],
+  "Chaos Orb": [
+    "Chaos Orb",
+    "Orbe do Caos",
+    "Сфера хаоса",
+    "Chaos Orb",
+    "Chaossphäre",
+    "Orbe du chaos",
+    "Orbe de caos",
+    "カオスオーブ",
+    "카오스 오브"
+  ],
+  "Exalted Orb": [
+    "Exalted Orb",
+    "Orbe Exaltado",
+    "Сфера возвышения",
+    "Exalted Orb",
+    "Erhabene Sphäre",
+    "Orbe exalté",
+    "Orbe exaltado",
+    "高貴なオーブ",
+    "엑잘티드 오브"
+  ],
+  "Divine Orb": [
+    "Divine Orb",
+    "Orbe Divino",
+    "Божественная сфера",
+    "Divine Orb",
+    "Göttliche Sphäre",
+    "Orbe divin",
+    "Orbe divino",
+    "神のオーブ",
+    "신성한 오브"
+  ]
 }
+
+const normalizeLabel = (value: string | null | undefined) =>
+  value?.replace(/\s+/g, " ").trim() || ""
 
 const findBuyoutFilter = () => {
   const filters = Array.from(
@@ -28,26 +92,37 @@ const findBuyoutFilter = () => {
 
   return (
     filters.find((filter) => {
-      const title = filter
-        .querySelector(".filter-title")
-        ?.textContent?.replace(/\s+/g, " ")
-        .trim()
-      return title === "Buyout Price"
+      const title = normalizeLabel(filter.querySelector(".filter-title")?.textContent)
+      return buyoutFilterTitles.includes(title)
     }) || null
   )
 }
 
-export const setBuyoutCurrencyPreset = (currency: string) => {
-  const multiselect = findBuyoutCurrencySelect()
+const getLocalizedCurrencyLabel = (
+  buyoutFilter: HTMLElement,
+  currency: BuyoutCurrency
+) => {
+  const title = normalizeLabel(
+    buyoutFilter.querySelector(".filter-title")?.textContent
+  )
+  const languageIndex = buyoutFilterTitles.indexOf(title)
+  return buyoutCurrencyLabels[currency][languageIndex] || currency
+}
+
+export const setBuyoutCurrencyPreset = (currency: BuyoutCurrency) => {
+  const buyoutFilter = findBuyoutFilter()
+  const multiselect = buyoutFilter?.querySelector<HTMLElement>(".multiselect")
   const input =
     multiselect?.querySelector<HTMLInputElement>("input.multiselect__input")
 
-  if (!multiselect || !input) return
+  if (!buyoutFilter || !multiselect || !input) return
 
   input.focus()
   input.click()
-  setNativeInputValue(input, currency)
-  input.setSelectionRange(currency.length, currency.length)
+  const localizedCurrency = getLocalizedCurrencyLabel(buyoutFilter, currency)
+
+  setNativeInputValue(input, localizedCurrency)
+  input.setSelectionRange(localizedCurrency.length, localizedCurrency.length)
   input.dispatchEvent(new Event("input", { bubbles: true }))
 
   queueMicrotask(() => {
@@ -55,7 +130,7 @@ export const setBuyoutCurrencyPreset = (currency: string) => {
       multiselect.querySelectorAll<HTMLElement>(".multiselect__option")
     ).find(
       (candidate) =>
-        candidate.textContent?.replace(/\s+/g, " ").trim() === currency
+        normalizeLabel(candidate.textContent) === localizedCurrency
     )
 
     option?.dispatchEvent(

--- a/lib/utilities/buyout-currency.ts
+++ b/lib/utilities/buyout-currency.ts
@@ -18,18 +18,23 @@ const setNativeInputValue = (input: HTMLInputElement, value: string) => {
 }
 
 const findBuyoutCurrencySelect = () => {
+  return findBuyoutFilter()?.querySelector<HTMLElement>(".multiselect") || null
+}
+
+const findBuyoutFilter = () => {
   const filters = Array.from(
     document.querySelectorAll<HTMLElement>(".filter.filter-property")
   )
-  const buyoutFilter = filters.find((filter) => {
-    const title = filter
-      .querySelector(".filter-title")
-      ?.textContent?.replace(/\s+/g, " ")
-      .trim()
-    return title === "Buyout Price"
-  })
 
-  return buyoutFilter?.querySelector<HTMLElement>(".multiselect") || null
+  return (
+    filters.find((filter) => {
+      const title = filter
+        .querySelector(".filter-title")
+        ?.textContent?.replace(/\s+/g, " ")
+        .trim()
+      return title === "Buyout Price"
+    }) || null
+  )
 }
 
 export const setBuyoutCurrencyPreset = (currency: string) => {
@@ -62,4 +67,8 @@ export const setBuyoutCurrencyPreset = (currency: string) => {
     )
     input.dispatchEvent(new Event("change", { bubbles: true }))
   })
+}
+
+export const clearBuyoutPrice = () => {
+  setBuyoutCurrencyPreset("Chaos Orb Equivalent")
 }

--- a/lib/utilities/trade-url.ts
+++ b/lib/utilities/trade-url.ts
@@ -21,12 +21,22 @@ export interface TradeUrlLike {
 export const resolveTradeLeague = (league: string | null | undefined, currentLeague: string | null | undefined = tradeLocationService.current.league) =>
   league || currentLeague || "Standard";
 
-export const resolveTradeUrl = (trade: TradeUrlLike, suffix: string = "") => {
+export const resolveTradeUrl = (
+  trade: TradeUrlLike,
+  suffix: string = "",
+  useActiveLeague: boolean = false
+) => {
+  const activeLocation = tradeLocationService.current;
+  const activeLeague =
+    useActiveLeague && activeLocation.version === trade.version
+      ? activeLocation.league
+      : null;
+
   return getTradeUrl(
     trade.version,
     trade.type,
     trade.slug,
-    resolveTradeLeague(trade.league),
+    resolveTradeLeague(activeLeague || trade.league),
     suffix
   );
 };

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "poe-trade-plus",
   "displayName": "Poe Trade Plus",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "license": "MIT",
   "description": "Poe Trade Plus enhances the Path of Exile trade site with bookmarks, history and result tools.",
   "author": "KroxiLabs",

--- a/scripts/release.cjs
+++ b/scripts/release.cjs
@@ -102,10 +102,10 @@ const assertReleaseNotes = () => {
 
 const releaseNotesPath = () => path.join(buildDir, `release-notes-${tag}.md`)
 const sourceArchivePath = () =>
-  path.join(buildDir, `${packageJson.displayName}-${version}-source.zip`)
+  path.join(buildDir, `${packageJson.name}-${version}-sources.zip`)
 const assetPaths = () => [
-  path.join(buildDir, `${packageJson.displayName}-${version}.zip`),
-  path.join(buildDir, `${packageJson.displayName}-${version}-firefox.zip`),
+  path.join(buildDir, `${packageJson.name}-${version}-chrome.zip`),
+  path.join(buildDir, `${packageJson.name}-${version}-firefox.zip`),
   sourceArchivePath()
 ]
 

--- a/scripts/release.cjs
+++ b/scripts/release.cjs
@@ -16,7 +16,22 @@ const upstreamRepository = "KroxiLabs/Kroxitrade"
 const languages = ["en", "es", "pt", "ru", "th", "de", "fr", "ja", "ko"]
 
 const run = (command, args, options = {}) => {
-  const result = childProcess.spawnSync(command, args, {
+  const useNpmCli = command === "npm" && !!process.env.npm_execpath
+  const useWindowsNpmShell =
+    command === "npm" && !useNpmCli && process.platform === "win32"
+  const quoteCommandArg = (value) =>
+    /[\s"]/u.test(value) ? `"${value.replace(/"/g, '\\"')}"` : value
+  const executable = useNpmCli
+    ? process.execPath
+    : useWindowsNpmShell
+      ? process.env.ComSpec || "cmd.exe"
+      : command
+  const commandArgs = useNpmCli
+    ? [process.env.npm_execpath, ...args]
+    : useWindowsNpmShell
+      ? ["/d", "/s", "/c", [command, ...args].map(quoteCommandArg).join(" ")]
+      : args
+  const result = childProcess.spawnSync(executable, commandArgs, {
     cwd: root,
     encoding: "utf8",
     stdio: options.capture ? ["ignore", "pipe", "pipe"] : "inherit"

--- a/scripts/release.cjs
+++ b/scripts/release.cjs
@@ -230,7 +230,25 @@ const publish = () => {
   const releaseArgs = ["release", "create", tag, ...assetPaths(), "--title", tag, "--notes-file", releaseNotesPath()]
   run("gh", [...releaseArgs, "--repo", originRepository])
   run("gh", [...releaseArgs, "--repo", upstreamRepository])
+
+  const currentBranch = run("git", ["branch", "--show-current"], {
+    capture: true
+  })
+  const localBranch = run("git", ["branch", "--list", releaseBranch], {
+    capture: true
+  })
+  if (currentBranch === releaseBranch) run("git", ["switch", "main"])
+
+  const remoteBranch = run(
+    "git",
+    ["ls-remote", "--heads", "origin", releaseBranch],
+    { capture: true }
+  )
+  if (remoteBranch) run("git", ["push", "origin", "--delete", releaseBranch])
+  if (localBranch) run("git", ["branch", "-D", releaseBranch])
+
   console.log(`Published ${tag} to ${originRepository} and ${upstreamRepository}.`)
+  console.log(`Deleted release branch: ${releaseBranch}`)
 }
 
 const action = process.argv[2]

--- a/scripts/wxt-runner.cjs
+++ b/scripts/wxt-runner.cjs
@@ -1,6 +1,7 @@
 const { spawn, spawnSync } = require("child_process")
 
 const args = process.argv.slice(2)
+const successGracePeriod = args[0] === "zip" ? 8000 : 1200
 
 if (args.length === 0) {
   console.error("Usage: node scripts/wxt-runner.cjs <wxt-args...>")
@@ -58,7 +59,7 @@ const scheduleSuccessExit = () => {
   successTimer = setTimeout(() => {
     killTree()
     finish(0)
-  }, 1200)
+  }, successGracePeriod)
 }
 
 const handleChunk = (stream, chunk) => {


### PR DESCRIPTION
# v1.1.7

## 1.1.7
### New features
- **Bookmarks follow active trade realm** — Saved searches now open in the active trade tab's current league and realm, while keeping their saved league as a fallback.
- **Clear Buyout Price shortcut** — Quick Filter Presets now include a Clear button that resets Buyout Price to Chaos Orb Equivalent and works with supported trade-site languages.

## 1.1.6
### New features
- **Wiki button for unique items** — Results can now show an optional W action on unique items that opens the matching PoE Wiki or PoE2 Wiki page.
- **Minimal bookmark layout** — Bookmarks now offer Classic, Compact, and Minimal layouts. Minimal keeps rows dense without changing the Path of Exile look.
- **Actions saved per layout** — Choose visible bookmark actions independently for Classic, Compact, and Minimal. Settings and preview update together.

## 1.1.5
### New features
- **Bookmark categories inside folders** — Saved searches can now be grouped into optional categories inside each bookmark folder. The feature is off by default, and turning it off returns every bookmark to the main folder list.
- **Cleaner bookmark action menus** — Category assignment, category creation, and category deletion now live inside the bookmark action menu, with inline creation and the same delete confirmation modal used elsewhere.

### Polish
- **Settings are more compact** — Long setting descriptions now appear as hover help, reducing visual clutter while keeping the details available when you need them.
- **General settings are clearer** — The Interface tab is now General, and Backup & Restore lives there alongside the other extension-wide options.

## 1.1.4
### New features
- **Adjustable text size** — Interface settings now include Small, Medium, Large, and Extra text sizes, with Large as the default.
- **Tutorial access moved to About** — The button to reopen the onboarding tutorial now lives in About, keeping Interface settings focused on display and language options.

## 1.1.3
### New features
- **Full extension backup** — Backup files now include saved folders, searches, global settings, PoE1/PoE2 result settings, and extension preferences in one portable JSON file.
- **Old folder backups still restore** — The restore action still accepts older folder-only .txt exports, so existing backups remain usable.

## 1.1.2
### New features
- **External reference links in the popup** — The popup can now show grouped PoE1 and PoE2 shortcuts for the official trade-adjacent tools, including the Path of Exile Wiki, Path of Exile 2 Wiki, Path of Regex, Craft of Exile, PoEDb, PoE2Db, and poe.ninja.
- **New PoE2 bookmark folder icons** — Disciple of Varashta, Martial Artist, and Spirit Walker icons are available for PoE2 bookmark folders.
- **Mageblood Legacy descriptions for PoE2** — A new Results setting can show hidden Mageblood Legacy effects below PoE2 item results, including duplicate Legacy scaling.

### Fixes
- **Localized PoE2 trade links load correctly** — Bookmarks and helper panels now recognize localized trade2 hosts such as es.pathofexile.com and keep league URLs with spaces encoded correctly.
- **Mageblood Legacy works across languages** — Legacy detection now uses stable trade stat ids, with localized effect descriptions for English, Spanish, Portuguese, Russian, Thai, German, French, Japanese, and Korean.

### Polish
- **Mageblood details stay quiet until hover** — Legacy descriptions show the final value by default, while base value and duplicate effect details appear inline on hover.
- **Mageblood descriptions match item layout** — Legacy description blocks now sit below corrupt/explicit separators like native notable descriptions and stay out of copied item text.

## 1.1.1
### Fixes
- **Foulborn items add the correct modifier** — Quick filter buttons now compensate for mutated Foulborn item rows where the trade site shifts modifier stat ids out of visual order.
- **Bookmark action buttons no longer open searches** — Editing, refreshing, duplicating, or opening the bookmark menu stays inside that action instead of triggering the saved search row.
- **PoE2 copy stays out of PoE1** — The Path of Building copy option is now only shown on the PoE2 trade site.
- **Craft of Exile buttons keep their shape** — The CoE action button is now a centered 30px square so it aligns cleanly with the result row controls.

### Polish
- **Craft of Exile copy avoids unsupported modifier slots** — Items with Prefix/Suffix Modifier allowed affixes now show a greyed CoE button with an explanation, while Copy for PoB keeps working.
- **Version-specific settings are clearer** — PoE1 and PoE2 can keep separate result-tool preferences where that matters, and PoE2-only tools stay hidden on PoE1.

## 1.1.0
### New features
- **Settings are now easier to navigate** — Customization is grouped into Interface, Sidebar, Results, and Bookmarks so each option has a clearer home.
- **Bookmark Layout now has a live preview** — The Bookmarks settings tab shows a real-time saved-search preview using the same action menu as the actual bookmark list.
- **What's New is now built into the sidebar** — New releases can show a compact update prompt, plus a full release notes modal from About.
- **Quick Filter Presets can live where you work** — Enable them from Results settings, then choose whether they appear in the sidebar or directly above the trade site's Stat Filters.
- **Craft of Exile export is easier to reach** — PoE1 and PoE2 result rows can now expose a CoE action that copies items in Craft of Exile's advanced import format.
- **PoE2 copy support for Path of Building** — A dedicated PoE2 copy option can surface beside other result actions and copy item text ready for PoB.
- **Equivalent pricing works across both games** — poe.ninja ratios now support PoE1 and PoE2 so chaos/divine conversion stays useful on either trade site.

### Polish
- **Sidebar and result options were separated** — Visible sidebar modules now live under Sidebar, while injected trade-result tools stay under Results.
- **Add To Filters moved out of the sidebar by default** — Quick filter presets can now be injected into the trade page, keeping the sidebar focused on navigation and saved searches.
- **Bookmark folders remember their open state** — Expanded and collapsed folders persist more predictably across sessions.
- **History labels and trade URLs are cleaner** — League names, fallbacks, and trade-link handling received small consistency improvements.
- **Result cards are easier to use** — Card click handling and seller panel accessibility were tightened for repeated trade workflows.

### Fixes
- **More reliable background messaging** — Background requests and bulk seller caching now handle failure cases more defensively.
- **Finer Filters hover behavior is smoother** — Compact result layouts and item filter buttons now behave more consistently.
- **Bookmark text opens saved searches again** — Clicking the saved-search title now opens the bookmark instead of being ignored.
- **Extension dependencies were hardened** — Dependency overrides and validation changes reduce known package and request risks.
