### PR TITLE
Release v1.1.14

### DIFF
--- a/components/BookmarkFolder.svelte
+++ b/components/BookmarkFolder.svelte
@@ -410,6 +410,7 @@
   let draggedIndex: number | null = $state(null)
   let dragOverIndex: number | null = $state(null)
   let suppressNextTradeOpen = false
+  let suppressNextFolderToggle = false
 
   const handleDragStart = (e: DragEvent, index: number) => {
     draggedIndex = index
@@ -495,6 +496,13 @@
   const openTrade = async (trade: BookmarksTradeStruct, inNewTab = false) => {
     const url = resolveTradeUrl(trade.location, "", true)
     await (inNewTab ? openUrlInNewTab(url) : openUrlInActiveTab(url))
+  }
+
+  const openAllTradesInNewTabs = async () => {
+    await loadTrades()
+    for (const trade of trades) {
+      await openTrade(trade, true)
+    }
   }
 
   const exportFolder = () => {
@@ -631,6 +639,20 @@
     }
   }
 
+  const handleFolderHeaderPointerDown = (event: PointerEvent) => {
+    if (event.button === 1) event.preventDefault()
+  }
+
+  const handleFolderHeaderPointerUp = (event: PointerEvent) => {
+    if (event.button !== 1 || editingFolder) return
+    event.preventDefault()
+    suppressNextFolderToggle = true
+    window.setTimeout(() => {
+      suppressNextFolderToggle = false
+    }, 0)
+    void openAllTradesInNewTabs()
+  }
+
   const handleTradeCardClick = (event: MouseEvent | PointerEvent, trade: BookmarksTradeStruct) => {
     if (shouldIgnoreTradeCardClick(event.target)) return
     if (event.button === 1) {
@@ -762,8 +784,14 @@
     <button
       type="button"
       class="expansion-wrapper"
+      onpointerdown={handleFolderHeaderPointerDown}
+      onpointerup={handleFolderHeaderPointerUp}
       onclick={(e) => {
         e.stopPropagation()
+        if (suppressNextFolderToggle) {
+          suppressNextFolderToggle = false
+          return
+        }
         if (!editingFolder) onToggleExpansion(folder.id || "")
       }}
       aria-expanded={isExpanded}

--- a/lib/data/whats-new.ts
+++ b/lib/data/whats-new.ts
@@ -81,6 +81,13 @@ const version1113Features: WhatsNewItem[] = [
   }
 ];
 
+const version1114Features: WhatsNewItem[] = [
+  {
+    titleKey: "whatsNew.item.middleClickFolderTitle",
+    descriptionKey: "whatsNew.item.middleClickFolderDescription"
+  }
+];
+
 const version112Features: WhatsNewItem[] = [
   {
     title: "External reference links in the popup",
@@ -333,9 +340,18 @@ const version1110Features: WhatsNewItem[] = [
 ];
 
 export const latestWhatsNew: WhatsNewEntry = {
-  version: "1.1.13",
-  date: "2026-07-21",
+  version: "1.1.14",
+  date: "2026-07-23",
   sections: [
+    {
+      title: "1.1.14",
+      groups: [
+        {
+          titleKey: "whatsNew.section.features",
+          items: version1114Features
+        }
+      ]
+    },
     {
       title: "1.1.13",
       groups: [

--- a/lib/services/i18n/de.ts
+++ b/lib/services/i18n/de.ts
@@ -11,6 +11,8 @@ export const germanTranslations: Record<string, TranslationValue> = {
   "whatsNew.item.bookmarkPreviewRealDescription": "Die Live-Vorschau nutzt jetzt echte Ordner- und Lesezeichenkomponenten mit Kategorien, zwei Beispielsuchen und layoutabhängigen Aktionen.",
   "whatsNew.item.middleClickAutoScrollTitle": "Mittelklick aktiviert kein automatisches Scrollen mehr",
   "whatsNew.item.middleClickAutoScrollDescription": "Ein Mittelklick auf eine gespeicherte Suche öffnet sie in einem Hintergrund-Tab, ohne den Auto-Scroll-Cursor des Browsers zu aktivieren.",
+  "whatsNew.item.middleClickFolderTitle": "Gespeicherte Suchen per Mittelklick auf Ordner öffnen",
+  "whatsNew.item.middleClickFolderDescription": "Ein Mittelklick auf einen Lesezeichenordner öffnet alle gespeicherten Suchen darin in Hintergrund-Tabs.",
   "whatsNew.item.kakaoTradeSupportTitle": "Unterstützung für die Kakao-Games-Handelsseite",
   "whatsNew.item.kakaoTradeSupportDescription": "Die Seitenleiste und Handelswerkzeuge funktionieren jetzt auf poe.kakaogames.com für PoE1 (/trade) und PoE2 (/trade2).",
   "settings.bookmarkPreviewTradeSecondary": "Schnelle Kartenräumung",

--- a/lib/services/i18n/en.ts
+++ b/lib/services/i18n/en.ts
@@ -63,6 +63,9 @@ export const englishTranslations: Record<string, TranslationValue> = {
   "whatsNew.item.middleClickAutoScrollTitle": "Middle-click no longer enables auto-scroll",
   "whatsNew.item.middleClickAutoScrollDescription":
     "Middle-clicking a saved search opens it in a background tab without activating the browser's auto-scroll cursor.",
+  "whatsNew.item.middleClickFolderTitle": "Middle-click folders to open saved searches",
+  "whatsNew.item.middleClickFolderDescription":
+    "Middle-click a bookmark folder to open all its saved searches in background tabs.",
   "whatsNew.item.kakaoTradeSupportTitle": "Kakao Games trade site support",
   "whatsNew.item.kakaoTradeSupportDescription":
     "The sidebar and trade helpers now work on poe.kakaogames.com for both PoE1 (/trade) and PoE2 (/trade2).",

--- a/lib/services/i18n/es.ts
+++ b/lib/services/i18n/es.ts
@@ -62,6 +62,9 @@ export const spanishTranslations: Record<string, TranslationValue> = {
   "whatsNew.item.middleClickAutoScrollTitle": "El clic central ya no activa el desplazamiento automático",
   "whatsNew.item.middleClickAutoScrollDescription":
     "El clic central en una búsqueda guardada la abre en una pestaña en segundo plano sin activar el cursor de desplazamiento automático del navegador.",
+  "whatsNew.item.middleClickFolderTitle": "Abre búsquedas guardadas con clic central en las carpetas",
+  "whatsNew.item.middleClickFolderDescription":
+    "Haz clic central en una carpeta de marcadores para abrir todas sus búsquedas guardadas en pestañas en segundo plano.",
   "whatsNew.item.kakaoTradeSupportTitle": "Compatibilidad con el sitio de trade de Kakao Games",
   "whatsNew.item.kakaoTradeSupportDescription":
     "El panel lateral y las herramientas de trade ahora funcionan en poe.kakaogames.com tanto para PoE1 (/trade) como para PoE2 (/trade2).",

--- a/lib/services/i18n/fr.ts
+++ b/lib/services/i18n/fr.ts
@@ -11,6 +11,8 @@ export const frenchTranslations: Record<string, TranslationValue> = {
   "whatsNew.item.bookmarkPreviewRealDescription": "L’aperçu en direct utilise maintenant les vrais composants de dossier et de favori, avec catégories, deux recherches d’exemple et actions propres à chaque disposition.",
   "whatsNew.item.middleClickAutoScrollTitle": "Le clic central n’active plus le défilement automatique",
   "whatsNew.item.middleClickAutoScrollDescription": "Un clic central sur une recherche sauvegardée l’ouvre dans un onglet en arrière-plan sans activer le curseur de défilement automatique du navigateur.",
+  "whatsNew.item.middleClickFolderTitle": "Ouvrez les recherches sauvegardées avec un clic central sur les dossiers",
+  "whatsNew.item.middleClickFolderDescription": "Un clic central sur un dossier de favoris ouvre toutes ses recherches sauvegardées dans des onglets en arrière-plan.",
   "whatsNew.item.kakaoTradeSupportTitle": "Prise en charge du site de commerce Kakao Games",
   "whatsNew.item.kakaoTradeSupportDescription": "La barre latérale et les outils de commerce fonctionnent désormais sur poe.kakaogames.com pour PoE1 (/trade) et PoE2 (/trade2).",
   "settings.bookmarkPreviewTradeSecondary": "Nettoyage rapide des cartes",

--- a/lib/services/i18n/ja.ts
+++ b/lib/services/i18n/ja.ts
@@ -11,6 +11,8 @@ export const japaneseTranslations: Record<string, TranslationValue> = {
   "whatsNew.item.bookmarkPreviewRealDescription": "ライブプレビューは実際のフォルダーとブックマークのコンポーネントを使い、カテゴリ、2つの検索例、レイアウト別の操作を表示します。",
   "whatsNew.item.middleClickAutoScrollTitle": "中クリックで自動スクロールが有効にならないように改善",
   "whatsNew.item.middleClickAutoScrollDescription": "保存した検索を中クリックすると、ブラウザーの自動スクロールカーソルを有効にせず、バックグラウンドタブで開きます。",
+  "whatsNew.item.middleClickFolderTitle": "フォルダーの中クリックで保存済み検索を開く",
+  "whatsNew.item.middleClickFolderDescription": "ブックマークフォルダーを中クリックすると、保存済みの検索をすべてバックグラウンドタブで開きます。",
   "whatsNew.item.kakaoTradeSupportTitle": "Kakao Games のトレードサイトに対応",
   "whatsNew.item.kakaoTradeSupportDescription": "サイドバーとトレード補助機能が、poe.kakaogames.com の PoE1 (/trade) と PoE2 (/trade2) で使えるようになりました。",
   "settings.bookmarkPreviewTradeSecondary": "高速マップ周回",

--- a/lib/services/i18n/ko.ts
+++ b/lib/services/i18n/ko.ts
@@ -11,6 +11,8 @@ export const koreanTranslations: Record<string, TranslationValue> = {
   "whatsNew.item.bookmarkPreviewRealDescription": "라이브 미리 보기는 실제 폴더와 북마크 구성 요소를 사용하며 카테고리, 두 개의 검색 예시 및 레이아웃별 작업을 보여 줍니다.",
   "whatsNew.item.middleClickAutoScrollTitle": "가운데 클릭이 자동 스크롤을 켜지 않도록 개선",
   "whatsNew.item.middleClickAutoScrollDescription": "저장된 검색을 가운데 클릭하면 브라우저의 자동 스크롤 커서를 켜지 않고 백그라운드 탭에서 열립니다.",
+  "whatsNew.item.middleClickFolderTitle": "폴더를 가운데 클릭해 저장된 검색 열기",
+  "whatsNew.item.middleClickFolderDescription": "북마크 폴더를 가운데 클릭하면 저장된 검색을 모두 백그라운드 탭에서 엽니다.",
   "whatsNew.item.kakaoTradeSupportTitle": "Kakao Games 거래 사이트 지원",
   "whatsNew.item.kakaoTradeSupportDescription": "이제 사이드바와 거래 도구를 poe.kakaogames.com의 PoE1 (/trade) 및 PoE2 (/trade2)에서 사용할 수 있습니다.",
   "settings.bookmarkPreviewTradeSecondary": "빠른 맵 클리어",

--- a/lib/services/i18n/pt.ts
+++ b/lib/services/i18n/pt.ts
@@ -11,6 +11,8 @@ export const portugueseTranslations: Record<string, TranslationValue> = {
   "whatsNew.item.bookmarkPreviewRealDescription": "A pré-visualização ao vivo agora usa componentes reais de pasta e favorito, com categorias, duas buscas de exemplo e ações específicas do layout.",
   "whatsNew.item.middleClickAutoScrollTitle": "O clique do meio já não ativa a rolagem automática",
   "whatsNew.item.middleClickAutoScrollDescription": "Clicar com o botão do meio numa busca guardada abre-a numa aba em segundo plano sem ativar o cursor de rolagem automática do navegador.",
+  "whatsNew.item.middleClickFolderTitle": "Abra buscas salvas com o clique do meio nas pastas",
+  "whatsNew.item.middleClickFolderDescription": "Clique com o botão do meio numa pasta de favoritos para abrir todas as suas buscas salvas em abas em segundo plano.",
   "whatsNew.item.kakaoTradeSupportTitle": "Suporte ao site de trade da Kakao Games",
   "whatsNew.item.kakaoTradeSupportDescription": "A barra lateral e as ferramentas de trade agora funcionam em poe.kakaogames.com tanto para PoE1 (/trade) como para PoE2 (/trade2).",
   "settings.bookmarkPreviewTradeSecondary": "Limpeza rápida de mapas",

--- a/lib/services/i18n/ru.ts
+++ b/lib/services/i18n/ru.ts
@@ -11,6 +11,8 @@ export const russianTranslations: Record<string, TranslationValue> = {
   "whatsNew.item.bookmarkPreviewRealDescription": "В предпросмотре теперь используются реальные компоненты папки и закладки: категории, два примера поиска и действия для каждого вида.",
   "whatsNew.item.middleClickAutoScrollTitle": "Средний клик больше не включает автопрокрутку",
   "whatsNew.item.middleClickAutoScrollDescription": "Средний клик по сохранённому поиску открывает его в фоновой вкладке, не включая курсор автопрокрутки браузера.",
+  "whatsNew.item.middleClickFolderTitle": "Открывайте сохранённые поиски средним кликом по папке",
+  "whatsNew.item.middleClickFolderDescription": "Средний клик по папке закладок открывает все сохранённые поиски в фоновых вкладках.",
   "whatsNew.item.kakaoTradeSupportTitle": "Поддержка сайта торговли Kakao Games",
   "whatsNew.item.kakaoTradeSupportDescription": "Боковая панель и торговые инструменты теперь работают на poe.kakaogames.com как для PoE1 (/trade), так и для PoE2 (/trade2).",
   "settings.bookmarkPreviewTradeSecondary": "Быстрая зачистка карт",

--- a/lib/services/i18n/th.ts
+++ b/lib/services/i18n/th.ts
@@ -11,6 +11,8 @@ export const thaiTranslations: Record<string, TranslationValue> = {
   "whatsNew.item.bookmarkPreviewRealDescription": "ตัวอย่างสดใช้คอมโพเนนต์โฟลเดอร์และบุ๊กมาร์กจริง พร้อมหมวดหมู่ การค้นหาตัวอย่างสองรายการ และการวางปุ่มตามรูปแบบ.",
   "whatsNew.item.middleClickAutoScrollTitle": "คลิกกลางจะไม่เปิดโหมดเลื่อนอัตโนมัติอีกต่อไป",
   "whatsNew.item.middleClickAutoScrollDescription": "การคลิกกลางที่การค้นหาที่บันทึกไว้จะเปิดในแท็บเบื้องหลังโดยไม่เปิดเคอร์เซอร์เลื่อนอัตโนมัติของเบราว์เซอร์.",
+  "whatsNew.item.middleClickFolderTitle": "คลิกกลางที่โฟลเดอร์เพื่อเปิดการค้นหาที่บันทึกไว้",
+  "whatsNew.item.middleClickFolderDescription": "คลิกกลางที่โฟลเดอร์บุ๊กมาร์กเพื่อเปิดการค้นหาที่บันทึกไว้ทั้งหมดในแท็บเบื้องหลัง.",
   "whatsNew.item.kakaoTradeSupportTitle": "รองรับเว็บไซต์ trade ของ Kakao Games",
   "whatsNew.item.kakaoTradeSupportDescription": "แถบด้านข้างและเครื่องมือ trade ใช้งานได้บน poe.kakaogames.com สำหรับทั้ง PoE1 (/trade) และ PoE2 (/trade2).",
   "settings.bookmarkPreviewTradeSecondary": "เคลียร์แผนที่อย่างรวดเร็ว",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "poe-trade-plus",
   "displayName": "Poe Trade Plus",
-  "version": "1.1.13",
+  "version": "1.1.14",
   "packageManager": "pnpm@11.3.0",
   "license": "MIT",
   "description": "Poe Trade Plus enhances the Path of Exile trade site with bookmarks, history and result tools.",

--- a/scripts/release.cjs
+++ b/scripts/release.cjs
@@ -272,8 +272,15 @@ const publish = () => {
   if (remoteBranch) run("git", ["push", "origin", "--delete", releaseBranch])
   if (localBranch) run("git", ["branch", "-D", releaseBranch])
 
+  run("git", ["fetch", "upstream", "main"])
+  run("git", ["switch", "main"])
+  run("git", ["merge", "--ff-only", "upstream/main"])
+  run("git", ["push", "origin", "main"])
+  run("pnpm", ["run", "version"])
+
   console.log(`Published ${tag} to ${originRepository} and ${upstreamRepository}.`)
   console.log(`Deleted release branch: ${releaseBranch}`)
+  console.log("Synchronized main with upstream and bumped the next patch version.")
 }
 
 const action = process.argv[2]


### PR DESCRIPTION
# v1.1.14

## 1.1.14
### New features
- **Middle-click folders to open saved searches** — Middle-click a bookmark folder to open all its saved searches in background tabs.

## 1.1.13
### New features
- **Kakao Games trade site support** — The sidebar and trade helpers now work on poe.kakaogames.com for both PoE1 (/trade) and PoE2 (/trade2).

## 1.1.12
### Fixes
- **Middle-click no longer enables auto-scroll** — Middle-clicking a saved search opens it in a background tab without activating the browser's auto-scroll cursor.

## 1.1.11
### New features
- **Guided tutorial refreshed** — The tutorial now follows the main workflows, groups related settings together, and keeps its guide cards out of the way of the controls they explain.
- **Bookmark Layout preview matches the real list** — The live preview now uses the real folder and bookmark components, including categories, two example searches, and the layout-specific action placement.

## 1.1.10
### New features
- **Open saved searches in new tabs** — Middle-click a saved search to open it in a background tab, so you can queue several searches without leaving the current one.
- **Bookmark icons are easier to browse** — The folder icon picker now groups currency and ascendancy icons, making the right icon faster to find.
- **Sidebar preferences are more reliable** — Sidebar defaults are shared consistently, and the Path of Building copy action remains visible where it is available on PoE2.

## 1.1.9
### Fixes
- **Bookmarks update more reliably** — Saved bookmark changes now validate stored data before updating the sidebar, preventing malformed or outdated storage entries from causing problems.
- **Cleaner Bookmark Layout preview** — The live Bookmark Layout preview no longer shows a league label, keeping the sample focused on the layout and actions.

## 1.1.8
### New features
- **Optional desecrated mods in Craft of Exile exports** — Craft of Exile exports now exclude desecrated mods by default. You can opt in from Results settings to include them as normal modifiers, with a warning that Craft of Exile does not yet support importing them.

## 1.1.7
### New features
- **Bookmarks follow active trade realm** — Saved searches now open in the active trade tab's current league and realm, while keeping their saved league as a fallback.
- **Clear Buyout Price shortcut** — Quick Filter Presets now include a Clear button that resets Buyout Price to Chaos Orb Equivalent and works with supported trade-site languages.

## 1.1.6
### New features
- **Wiki button for unique items** — Results can now show an optional W action on unique items that opens the matching PoE Wiki or PoE2 Wiki page.
- **Minimal bookmark layout** — Bookmarks now offer Classic, Compact, and Minimal layouts. Minimal keeps rows dense without changing the Path of Exile look.
- **Actions saved per layout** — Choose visible bookmark actions independently for Classic, Compact, and Minimal. Settings and preview update together.

## 1.1.5
### New features
- **Bookmark categories inside folders** — Saved searches can now be grouped into optional categories inside each bookmark folder. The feature is off by default, and turning it off returns every bookmark to the main folder list.
- **Cleaner bookmark action menus** — Category assignment, category creation, and category deletion now live inside the bookmark action menu, with inline creation and the same delete confirmation modal used elsewhere.

### Polish
- **Settings are more compact** — Long setting descriptions now appear as hover help, reducing visual clutter while keeping the details available when you need them.
- **General settings are clearer** — The Interface tab is now General, and Backup & Restore lives there alongside the other extension-wide options.

## 1.1.4
### New features
- **Adjustable text size** — Interface settings now include Small, Medium, Large, and Extra text sizes, with Large as the default.
- **Tutorial access moved to About** — The button to reopen the onboarding tutorial now lives in About, keeping Interface settings focused on display and language options.

## 1.1.3
### New features
- **Full extension backup** — Backup files now include saved folders, searches, global settings, PoE1/PoE2 result settings, and extension preferences in one portable JSON file.
- **Old folder backups still restore** — The restore action still accepts older folder-only .txt exports, so existing backups remain usable.

## 1.1.2
### New features
- **External reference links in the popup** — The popup can now show grouped PoE1 and PoE2 shortcuts for the official trade-adjacent tools, including the Path of Exile Wiki, Path of Exile 2 Wiki, Path of Regex, Craft of Exile, PoEDb, PoE2Db, and poe.ninja.
- **New PoE2 bookmark folder icons** — Disciple of Varashta, Martial Artist, and Spirit Walker icons are available for PoE2 bookmark folders.
- **Mageblood Legacy descriptions for PoE2** — A new Results setting can show hidden Mageblood Legacy effects below PoE2 item results, including duplicate Legacy scaling.

### Fixes
- **Localized PoE2 trade links load correctly** — Bookmarks and helper panels now recognize localized trade2 hosts such as es.pathofexile.com and keep league URLs with spaces encoded correctly.
- **Mageblood Legacy works across languages** — Legacy detection now uses stable trade stat ids, with localized effect descriptions for English, Spanish, Portuguese, Russian, Thai, German, French, Japanese, and Korean.

### Polish
- **Mageblood details stay quiet until hover** — Legacy descriptions show the final value by default, while base value and duplicate effect details appear inline on hover.
- **Mageblood descriptions match item layout** — Legacy description blocks now sit below corrupt/explicit separators like native notable descriptions and stay out of copied item text.

## 1.1.1
### Fixes
- **Foulborn items add the correct modifier** — Quick filter buttons now compensate for mutated Foulborn item rows where the trade site shifts modifier stat ids out of visual order.
- **Bookmark action buttons no longer open searches** — Editing, refreshing, duplicating, or opening the bookmark menu stays inside that action instead of triggering the saved search row.
- **PoE2 copy stays out of PoE1** — The Path of Building copy option is now only shown on the PoE2 trade site.
- **Craft of Exile buttons keep their shape** — The CoE action button is now a centered 30px square so it aligns cleanly with the result row controls.

### Polish
- **Craft of Exile copy avoids unsupported modifier slots** — Items with Prefix/Suffix Modifier allowed affixes now show a greyed CoE button with an explanation, while Copy for PoB keeps working.
- **Version-specific settings are clearer** — PoE1 and PoE2 can keep separate result-tool preferences where that matters, and PoE2-only tools stay hidden on PoE1.

## 1.1.0
### New features
- **Settings are now easier to navigate** — Customization is grouped into Interface, Sidebar, Results, and Bookmarks so each option has a clearer home.
- **Bookmark Layout now has a live preview** — The Bookmarks settings tab shows a real-time saved-search preview using the same action menu as the actual bookmark list.
- **What's New is now built into the sidebar** — New releases can show a compact update prompt, plus a full release notes modal from About.
- **Quick Filter Presets can live where you work** — Enable them from Results settings, then choose whether they appear in the sidebar or directly above the trade site's Stat Filters.
- **Craft of Exile export is easier to reach** — PoE1 and PoE2 result rows can now expose a CoE action that copies items in Craft of Exile's advanced import format.
- **PoE2 copy support for Path of Building** — A dedicated PoE2 copy option can surface beside other result actions and copy item text ready for PoB.
- **Equivalent pricing works across both games** — poe.ninja ratios now support PoE1 and PoE2 so chaos/divine conversion stays useful on either trade site.

### Polish
- **Sidebar and result options were separated** — Visible sidebar modules now live under Sidebar, while injected trade-result tools stay under Results.
- **Add To Filters moved out of the sidebar by default** — Quick filter presets can now be injected into the trade page, keeping the sidebar focused on navigation and saved searches.
- **Bookmark folders remember their open state** — Expanded and collapsed folders persist more predictably across sessions.
- **History labels and trade URLs are cleaner** — League names, fallbacks, and trade-link handling received small consistency improvements.
- **Result cards are easier to use** — Card click handling and seller panel accessibility were tightened for repeated trade workflows.

### Fixes
- **More reliable background messaging** — Background requests and bulk seller caching now handle failure cases more defensively.
- **Finer Filters hover behavior is smoother** — Compact result layouts and item filter buttons now behave more consistently.
- **Bookmark text opens saved searches again** — Clicking the saved-search title now opens the bookmark instead of being ignored.
- **Extension dependencies were hardened** — Dependency overrides and validation changes reduce known package and request risks.
