### PR TITLE
Release v1.1.16

### DIFF
--- a/lib/data/whats-new.ts
+++ b/lib/data/whats-new.ts
@@ -88,6 +88,13 @@ const version1114Features: WhatsNewItem[] = [
   }
 ];
 
+const version1116Fixes: WhatsNewItem[] = [
+  {
+    titleKey: "whatsNew.item.mediumTextSizeTitle",
+    descriptionKey: "whatsNew.item.mediumTextSizeDescription"
+  }
+];
+
 const version112Features: WhatsNewItem[] = [
   {
     title: "External reference links in the popup",
@@ -340,9 +347,18 @@ const version1110Features: WhatsNewItem[] = [
 ];
 
 export const latestWhatsNew: WhatsNewEntry = {
-  version: "1.1.14",
-  date: "2026-07-23",
+  version: "1.1.16",
+  date: "2026-07-24",
   sections: [
+    {
+      title: "1.1.16",
+      groups: [
+        {
+          titleKey: "whatsNew.section.fixes",
+          items: version1116Fixes
+        }
+      ]
+    },
     {
       title: "1.1.14",
       groups: [

--- a/lib/services/i18n/de.ts
+++ b/lib/services/i18n/de.ts
@@ -2,6 +2,9 @@ import { englishTranslations } from "./en"
 import type { TranslationValue } from "./types"
 
 export const germanTranslations: Record<string, TranslationValue> = {
+  "whatsNew.item.mediumTextSizeTitle": "Mittlere Textgröße funktioniert korrekt",
+  "whatsNew.item.mediumTextSizeDescription":
+    "Die Auswahl von Mittel in den allgemeinen Einstellungen bleibt jetzt auch nach dem Neuladen der Erweiterung erhalten.",
   ...englishTranslations,
   "whatsNew.item.version1110Title": "Mehr Ordnersymbole und PoE2-Kopie wiederhergestellt",
   "whatsNew.item.version1110Description": "Ordnersymbole sind nach PoE1- und PoE2-Währungen sowie Aszendenzen organisiert; die Path-of-Building-Kopie ist wieder in PoE2-Ergebnissen verfügbar.",

--- a/lib/services/i18n/en.ts
+++ b/lib/services/i18n/en.ts
@@ -1,6 +1,9 @@
 import type { TranslationValue } from "./types"
 
 export const englishTranslations: Record<string, TranslationValue> = {
+  "whatsNew.item.mediumTextSizeTitle": "Medium text size works correctly",
+  "whatsNew.item.mediumTextSizeDescription":
+    "Selecting Medium in General settings now keeps your preferred text size after the extension reloads.",
   "app.name": "Poe Trade Plus",
   "header.subtitle": "Trade Companion",
   "header.expandSidebar": "Expand Sidebar",

--- a/lib/services/i18n/es.ts
+++ b/lib/services/i18n/es.ts
@@ -1,6 +1,9 @@
 import type { TranslationValue } from "./types"
 
 export const spanishTranslations: Record<string, TranslationValue> = {
+  "whatsNew.item.mediumTextSizeTitle": "El tamaño de texto Mediano funciona correctamente",
+  "whatsNew.item.mediumTextSizeDescription":
+    "Al seleccionar Mediano en los ajustes Generales, se conserva el tamaño de texto preferido tras recargar la extensión.",
   "app.name": "Poe Trade Plus",
   "header.subtitle": "Compañero de Trade",
   "header.expandSidebar": "Expandir panel",

--- a/lib/services/i18n/fr.ts
+++ b/lib/services/i18n/fr.ts
@@ -2,6 +2,9 @@ import { englishTranslations } from "./en"
 import type { TranslationValue } from "./types"
 
 export const frenchTranslations: Record<string, TranslationValue> = {
+  "whatsNew.item.mediumTextSizeTitle": "La taille de texte moyenne fonctionne correctement",
+  "whatsNew.item.mediumTextSizeDescription":
+    "Sélectionner Moyenne dans les paramètres généraux conserve désormais votre taille de texte après le rechargement de l’extension.",
   ...englishTranslations,
   "whatsNew.item.version1110Title": "Plus d’icônes de dossier et copie PoE2 restaurée",
   "whatsNew.item.version1110Description": "Les icônes de dossier sont organisées par monnaies et ascendances PoE1 et PoE2, et la copie Path of Building est de nouveau disponible dans les résultats PoE2.",

--- a/lib/services/i18n/ja.ts
+++ b/lib/services/i18n/ja.ts
@@ -2,6 +2,9 @@ import { englishTranslations } from "./en"
 import type { TranslationValue } from "./types"
 
 export const japaneseTranslations: Record<string, TranslationValue> = {
+  "whatsNew.item.mediumTextSizeTitle": "中サイズの文字が正しく機能するようになりました",
+  "whatsNew.item.mediumTextSizeDescription":
+    "一般設定で中を選択すると、拡張機能を再読み込みした後も文字サイズの設定が保持されます。",
   ...englishTranslations,
   "whatsNew.item.version1110Title": "フォルダーアイコンの拡充と PoE2 コピーの復元",
   "whatsNew.item.version1110Description": "フォルダーアイコンを PoE1 と PoE2 の通貨・アセンダンシーごとに整理し、Path of Building 用コピーを PoE2 の結果で再び利用できるようにしました。",

--- a/lib/services/i18n/ko.ts
+++ b/lib/services/i18n/ko.ts
@@ -2,6 +2,9 @@ import { englishTranslations } from "./en"
 import type { TranslationValue } from "./types"
 
 export const koreanTranslations: Record<string, TranslationValue> = {
+  "whatsNew.item.mediumTextSizeTitle": "중간 텍스트 크기가 올바르게 작동합니다",
+  "whatsNew.item.mediumTextSizeDescription":
+    "일반 설정에서 중간을 선택하면 확장 프로그램을 다시 로드한 후에도 텍스트 크기 설정이 유지됩니다.",
   ...englishTranslations,
   "whatsNew.item.version1110Title": "폴더 아이콘 확장 및 PoE2 복사 복원",
   "whatsNew.item.version1110Description": "폴더 아이콘을 PoE1 및 PoE2 화폐와 전직별로 정리했고, Path of Building용 복사를 PoE2 결과에서 다시 사용할 수 있습니다.",

--- a/lib/services/i18n/pt.ts
+++ b/lib/services/i18n/pt.ts
@@ -2,6 +2,9 @@ import { englishTranslations } from "./en"
 import type { TranslationValue } from "./types"
 
 export const portugueseTranslations: Record<string, TranslationValue> = {
+  "whatsNew.item.mediumTextSizeTitle": "O tamanho de texto Médio funciona corretamente",
+  "whatsNew.item.mediumTextSizeDescription":
+    "Selecionar Médio nas configurações Gerais agora mantém o tamanho de texto preferido depois que a extensão é recarregada.",
   ...englishTranslations,
   "whatsNew.item.version1110Title": "Mais ícones de pasta e cópia PoE2 restaurada",
   "whatsNew.item.version1110Description": "Os ícones de pasta são organizados por moedas e ascendências de PoE1 e PoE2, e a cópia para Path of Building voltou aos resultados de PoE2.",

--- a/lib/services/i18n/ru.ts
+++ b/lib/services/i18n/ru.ts
@@ -2,6 +2,9 @@ import { englishTranslations } from "./en"
 import type { TranslationValue } from "./types"
 
 export const russianTranslations: Record<string, TranslationValue> = {
+  "whatsNew.item.mediumTextSizeTitle": "Средний размер текста работает корректно",
+  "whatsNew.item.mediumTextSizeDescription":
+    "Выбор среднего размера в общих настройках теперь сохраняется после перезагрузки расширения.",
   ...englishTranslations,
   "whatsNew.item.version1110Title": "Больше иконок папок и восстановленная копия PoE2",
   "whatsNew.item.version1110Description": "Иконки папок упорядочены по валютам и возвышениям PoE1 и PoE2, а копирование для Path of Building снова доступно в результатах PoE2.",

--- a/lib/services/i18n/th.ts
+++ b/lib/services/i18n/th.ts
@@ -2,6 +2,9 @@ import { englishTranslations } from "./en"
 import type { TranslationValue } from "./types"
 
 export const thaiTranslations: Record<string, TranslationValue> = {
+  "whatsNew.item.mediumTextSizeTitle": "ขนาดข้อความปานกลางทำงานได้ถูกต้อง",
+  "whatsNew.item.mediumTextSizeDescription":
+    "การเลือกขนาดปานกลางในการตั้งค่าทั่วไปจะคงขนาดข้อความที่ต้องการไว้หลังจากโหลดส่วนขยายใหม่.",
   ...englishTranslations,
   "whatsNew.item.version1110Title": "เพิ่มไอคอนโฟลเดอร์และคืนค่าการคัดลอก PoE2",
   "whatsNew.item.version1110Description": "ไอคอนโฟลเดอร์จัดตามสกุลเงินและสายอาชีพ PoE1 และ PoE2 และการคัดลอกสำหรับ Path of Building กลับมาใช้ได้ในผลลัพธ์ PoE2.",

--- a/lib/services/settings.ts
+++ b/lib/services/settings.ts
@@ -83,6 +83,7 @@ const DEFAULT_VERSION_SETTINGS: VersionSettings = {
 
 function normalizeTextSize(textSize: unknown): TextSizePreference {
   return textSize === "small" ||
+    textSize === "medium" ||
     textSize === "large" ||
     textSize === "extraLarge"
     ? textSize

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "poe-trade-plus",
   "displayName": "Poe Trade Plus",
-  "version": "1.1.14",
+  "version": "1.1.16",
   "packageManager": "pnpm@11.3.0",
   "license": "MIT",
   "description": "Poe Trade Plus enhances the Path of Exile trade site with bookmarks, history and result tools.",


### PR DESCRIPTION
# v1.1.16

## 1.1.16
### Fixes
- **Medium text size works correctly** — Selecting Medium in General settings now keeps your preferred text size after the extension reloads.

## 1.1.14
### New features
- **Middle-click folders to open saved searches** — Middle-click a bookmark folder to open all its saved searches in background tabs.

## 1.1.13
### New features
- **Kakao Games trade site support** — The sidebar and trade helpers now work on poe.kakaogames.com for both PoE1 (/trade) and PoE2 (/trade2).

## 1.1.12
### Fixes
- **Middle-click no longer enables auto-scroll** — Middle-clicking a saved search opens it in a background tab without activating the browser's auto-scroll cursor.

## 1.1.11
### New features
- **Guided tutorial refreshed** — The tutorial now follows the main workflows, groups related settings together, and keeps its guide cards out of the way of the controls they explain.
- **Bookmark Layout preview matches the real list** — The live preview now uses the real folder and bookmark components, including categories, two example searches, and the layout-specific action placement.

## 1.1.10
### New features
- **Open saved searches in new tabs** — Middle-click a saved search to open it in a background tab, so you can queue several searches without leaving the current one.
- **Bookmark icons are easier to browse** — The folder icon picker now groups currency and ascendancy icons, making the right icon faster to find.
- **Sidebar preferences are more reliable** — Sidebar defaults are shared consistently, and the Path of Building copy action remains visible where it is available on PoE2.

## 1.1.9
### Fixes
- **Bookmarks update more reliably** — Saved bookmark changes now validate stored data before updating the sidebar, preventing malformed or outdated storage entries from causing problems.
- **Cleaner Bookmark Layout preview** — The live Bookmark Layout preview no longer shows a league label, keeping the sample focused on the layout and actions.

## 1.1.8
### New features
- **Optional desecrated mods in Craft of Exile exports** — Craft of Exile exports now exclude desecrated mods by default. You can opt in from Results settings to include them as normal modifiers, with a warning that Craft of Exile does not yet support importing them.

## 1.1.7
### New features
- **Bookmarks follow active trade realm** — Saved searches now open in the active trade tab's current league and realm, while keeping their saved league as a fallback.
- **Clear Buyout Price shortcut** — Quick Filter Presets now include a Clear button that resets Buyout Price to Chaos Orb Equivalent and works with supported trade-site languages.

## 1.1.6
### New features
- **Wiki button for unique items** — Results can now show an optional W action on unique items that opens the matching PoE Wiki or PoE2 Wiki page.
- **Minimal bookmark layout** — Bookmarks now offer Classic, Compact, and Minimal layouts. Minimal keeps rows dense without changing the Path of Exile look.
- **Actions saved per layout** — Choose visible bookmark actions independently for Classic, Compact, and Minimal. Settings and preview update together.

## 1.1.5
### New features
- **Bookmark categories inside folders** — Saved searches can now be grouped into optional categories inside each bookmark folder. The feature is off by default, and turning it off returns every bookmark to the main folder list.
- **Cleaner bookmark action menus** — Category assignment, category creation, and category deletion now live inside the bookmark action menu, with inline creation and the same delete confirmation modal used elsewhere.

### Polish
- **Settings are more compact** — Long setting descriptions now appear as hover help, reducing visual clutter while keeping the details available when you need them.
- **General settings are clearer** — The Interface tab is now General, and Backup & Restore lives there alongside the other extension-wide options.

## 1.1.4
### New features
- **Adjustable text size** — Interface settings now include Small, Medium, Large, and Extra text sizes, with Large as the default.
- **Tutorial access moved to About** — The button to reopen the onboarding tutorial now lives in About, keeping Interface settings focused on display and language options.

## 1.1.3
### New features
- **Full extension backup** — Backup files now include saved folders, searches, global settings, PoE1/PoE2 result settings, and extension preferences in one portable JSON file.
- **Old folder backups still restore** — The restore action still accepts older folder-only .txt exports, so existing backups remain usable.

## 1.1.2
### New features
- **External reference links in the popup** — The popup can now show grouped PoE1 and PoE2 shortcuts for the official trade-adjacent tools, including the Path of Exile Wiki, Path of Exile 2 Wiki, Path of Regex, Craft of Exile, PoEDb, PoE2Db, and poe.ninja.
- **New PoE2 bookmark folder icons** — Disciple of Varashta, Martial Artist, and Spirit Walker icons are available for PoE2 bookmark folders.
- **Mageblood Legacy descriptions for PoE2** — A new Results setting can show hidden Mageblood Legacy effects below PoE2 item results, including duplicate Legacy scaling.

### Fixes
- **Localized PoE2 trade links load correctly** — Bookmarks and helper panels now recognize localized trade2 hosts such as es.pathofexile.com and keep league URLs with spaces encoded correctly.
- **Mageblood Legacy works across languages** — Legacy detection now uses stable trade stat ids, with localized effect descriptions for English, Spanish, Portuguese, Russian, Thai, German, French, Japanese, and Korean.

### Polish
- **Mageblood details stay quiet until hover** — Legacy descriptions show the final value by default, while base value and duplicate effect details appear inline on hover.
- **Mageblood descriptions match item layout** — Legacy description blocks now sit below corrupt/explicit separators like native notable descriptions and stay out of copied item text.

## 1.1.1
### Fixes
- **Foulborn items add the correct modifier** — Quick filter buttons now compensate for mutated Foulborn item rows where the trade site shifts modifier stat ids out of visual order.
- **Bookmark action buttons no longer open searches** — Editing, refreshing, duplicating, or opening the bookmark menu stays inside that action instead of triggering the saved search row.
- **PoE2 copy stays out of PoE1** — The Path of Building copy option is now only shown on the PoE2 trade site.
- **Craft of Exile buttons keep their shape** — The CoE action button is now a centered 30px square so it aligns cleanly with the result row controls.

### Polish
- **Craft of Exile copy avoids unsupported modifier slots** — Items with Prefix/Suffix Modifier allowed affixes now show a greyed CoE button with an explanation, while Copy for PoB keeps working.
- **Version-specific settings are clearer** — PoE1 and PoE2 can keep separate result-tool preferences where that matters, and PoE2-only tools stay hidden on PoE1.

## 1.1.0
### New features
- **Settings are now easier to navigate** — Customization is grouped into Interface, Sidebar, Results, and Bookmarks so each option has a clearer home.
- **Bookmark Layout now has a live preview** — The Bookmarks settings tab shows a real-time saved-search preview using the same action menu as the actual bookmark list.
- **What's New is now built into the sidebar** — New releases can show a compact update prompt, plus a full release notes modal from About.
- **Quick Filter Presets can live where you work** — Enable them from Results settings, then choose whether they appear in the sidebar or directly above the trade site's Stat Filters.
- **Craft of Exile export is easier to reach** — PoE1 and PoE2 result rows can now expose a CoE action that copies items in Craft of Exile's advanced import format.
- **PoE2 copy support for Path of Building** — A dedicated PoE2 copy option can surface beside other result actions and copy item text ready for PoB.
- **Equivalent pricing works across both games** — poe.ninja ratios now support PoE1 and PoE2 so chaos/divine conversion stays useful on either trade site.

### Polish
- **Sidebar and result options were separated** — Visible sidebar modules now live under Sidebar, while injected trade-result tools stay under Results.
- **Add To Filters moved out of the sidebar by default** — Quick filter presets can now be injected into the trade page, keeping the sidebar focused on navigation and saved searches.
- **Bookmark folders remember their open state** — Expanded and collapsed folders persist more predictably across sessions.
- **History labels and trade URLs are cleaner** — League names, fallbacks, and trade-link handling received small consistency improvements.
- **Result cards are easier to use** — Card click handling and seller panel accessibility were tightened for repeated trade workflows.

### Fixes
- **More reliable background messaging** — Background requests and bulk seller caching now handle failure cases more defensively.
- **Finer Filters hover behavior is smoother** — Compact result layouts and item filter buttons now behave more consistently.
- **Bookmark text opens saved searches again** — Clicking the saved-search title now opens the bookmark instead of being ignored.
- **Extension dependencies were hardened** — Dependency overrides and validation changes reduce known package and request risks.
