### PR TITLE
Release v1.1.17

### DIFF
--- a/lib/data/whats-new.ts
+++ b/lib/data/whats-new.ts
@@ -95,6 +95,13 @@ const version1116Fixes: WhatsNewItem[] = [
   }
 ];
 
+const version1117Features: WhatsNewItem[] = [
+  {
+    titleKey: "whatsNew.item.syncAcrossDevicesTitle",
+    descriptionKey: "whatsNew.item.syncAcrossDevicesDescription"
+  }
+];
+
 const version112Features: WhatsNewItem[] = [
   {
     title: "External reference links in the popup",
@@ -347,9 +354,18 @@ const version1110Features: WhatsNewItem[] = [
 ];
 
 export const latestWhatsNew: WhatsNewEntry = {
-  version: "1.1.16",
+  version: "1.1.17",
   date: "2026-07-24",
   sections: [
+    {
+      title: "1.1.17",
+      groups: [
+        {
+          titleKey: "whatsNew.section.features",
+          items: version1117Features
+        }
+      ]
+    },
     {
       title: "1.1.16",
       groups: [

--- a/lib/services/bookmarks.ts
+++ b/lib/services/bookmarks.ts
@@ -14,8 +14,13 @@ import { languageStore, translate } from "./i18n"
 import { storageService, type StorageArea } from "./storage"
 
 const FOLDERS_KEY = "bookmark-folders"
+const FOLDERS_MANIFEST_KEY = "bookmark-folders-manifest"
+const FOLDERS_CHUNK_PREFIX = "bookmark-folders-chunk--"
 const TRADES_PREFIX_KEY = "bookmark-trades"
+const TRADES_MANIFEST_PREFIX = "bookmark-trades-manifest--"
+const TRADES_CHUNK_PREFIX = "bookmark-trades-chunk--"
 const BOOKMARKS_STORAGE_AREA: StorageArea = "sync"
+const FOLDERS_CHUNK_TARGET_BYTES = 6 * 1024
 const SECTION_DELIMITER = "\n--------------------\n"
 const LINE_DELIMITER = "\n"
 
@@ -50,11 +55,18 @@ interface ExportedFolderStruct {
   trs: Array<{ tit: string; loc: string; cat?: string }>
 }
 
+interface FoldersManifest {
+  version: 1
+  chunkKeys: string[]
+}
+
 export class BookmarksService {
   private foldersStore = writable<BookmarksFolderStruct[]>([])
   private listeners = new Set<(event?: BookmarksChangeEvent) => void>()
   private tradesCache = new Map<string, BookmarksTradeStruct[]>()
   private tradesRequests = new Map<string, Promise<BookmarksTradeStruct[]>>()
+  private foldersMigration: Promise<void> | null = null
+  private tradesMigrations = new Map<string, Promise<void>>()
   public subscribe = this.foldersStore.subscribe
 
   constructor() {
@@ -83,26 +95,25 @@ export class BookmarksService {
     chrome.storage.onChanged.addListener((changes, areaName) => {
       if (areaName !== BOOKMARKS_STORAGE_AREA) return
 
-      const foldersChange = changes[FOLDERS_KEY]
-      if (foldersChange) {
-        const folders = this.normalizeFolders(
-          getStorageChangeValue<Partial<BookmarksFolderStruct>[]>(foldersChange)
-        )
-        this.foldersStore.set(folders)
-        this.notifyChange({ foldersChanged: true })
+      const foldersChanged = Object.keys(changes).some(
+        (key) =>
+          key === FOLDERS_KEY ||
+          key === FOLDERS_MANIFEST_KEY ||
+          key.startsWith(FOLDERS_CHUNK_PREFIX)
+      )
+      if (foldersChanged) {
+        void this.refresh()
       }
 
-      const tradesPrefix = `${TRADES_PREFIX_KEY}--`
-      for (const [key, change] of Object.entries(changes)) {
-        if (!key.startsWith(tradesPrefix)) continue
-
-        const folderId = key.slice(tradesPrefix.length)
-        const trades = this.normalizeTrades(
-          getStorageChangeValue<BookmarksTradeStruct[]>(change)
-        )
-        this.tradesCache.set(folderId, trades)
+      const changedTradeFolderIds = new Set<string>()
+      for (const key of Object.keys(changes)) {
+        const folderId = this.getTradeFolderIdFromStorageKey(key)
+        if (folderId) changedTradeFolderIds.add(folderId)
+      }
+      for (const folderId of changedTradeFolderIds) {
+        this.tradesCache.delete(folderId)
         this.tradesRequests.delete(folderId)
-        this.notifyChange({ tradesChanged: true, folderId })
+        void this.refreshTradesFromStorage(folderId)
       }
     })
   }
@@ -110,10 +121,324 @@ export class BookmarksService {
   // ─── STORAGE ──────────────────────────────────────────────
 
   async fetchFolders(): Promise<BookmarksFolderStruct[]> {
-    const folders = await this.fetchSynced<Partial<BookmarksFolderStruct>[]>(
+    const chunkedFolders = await this.fetchChunkedFolders()
+    if (chunkedFolders !== null) return this.normalizeFolders(chunkedFolders)
+
+    const legacyFolders = await this.fetchSynced<
+      Partial<BookmarksFolderStruct>[]
+    >(
       FOLDERS_KEY
     )
-    return this.normalizeFolders(folders)
+    if (legacyFolders && legacyFolders.length > 0) {
+      await this.migrateFoldersToChunks(legacyFolders)
+    }
+
+    return this.normalizeFolders(legacyFolders)
+  }
+
+  private async fetchChunkedFolders(): Promise<
+    Partial<BookmarksFolderStruct>[] | null
+  > {
+    const manifest = await storageService.getValue<FoldersManifest>(
+      FOLDERS_MANIFEST_KEY,
+      null,
+      BOOKMARKS_STORAGE_AREA
+    )
+    if (
+      !manifest ||
+      manifest.version !== 1 ||
+      !Array.isArray(manifest.chunkKeys)
+    ) {
+      return null
+    }
+
+    const chunks = await Promise.all(
+      manifest.chunkKeys.map((key) =>
+        storageService.getValue<Partial<BookmarksFolderStruct>[]>(
+          key,
+          null,
+          BOOKMARKS_STORAGE_AREA
+        )
+      )
+    )
+    if (chunks.some((chunk) => chunk === null)) return null
+
+    return chunks.flatMap((chunk) => chunk || [])
+  }
+
+  private chunkFolders(
+    folders: BookmarksFolderStruct[]
+  ): Partial<BookmarksFolderStruct>[][] {
+    const chunks: Partial<BookmarksFolderStruct>[][] = []
+    let current: Partial<BookmarksFolderStruct>[] = []
+
+    for (const folder of folders) {
+      const candidate = [...current, folder]
+      const key = `${FOLDERS_CHUNK_PREFIX}${chunks.length}`
+      if (
+        current.length > 0 &&
+        this.storagePayloadBytes(key, candidate) > FOLDERS_CHUNK_TARGET_BYTES
+      ) {
+        chunks.push(current)
+        current = [folder]
+      } else {
+        current = candidate
+      }
+
+      if (
+        this.storagePayloadBytes(
+          `${FOLDERS_CHUNK_PREFIX}${chunks.length}`,
+          current
+        ) > 8192
+      ) {
+        throw new Error("A bookmark folder is too large to synchronize")
+      }
+    }
+
+    if (current.length > 0) chunks.push(current)
+    return chunks
+  }
+
+  private storagePayloadBytes(key: string, value: unknown): number {
+    return new TextEncoder().encode(
+      key + JSON.stringify({ expiresAt: null, value })
+    ).length
+  }
+
+  private async migrateFoldersToChunks(
+    folders: Partial<BookmarksFolderStruct>[]
+  ): Promise<void> {
+    if (!this.foldersMigration) {
+      this.foldersMigration = this.persistFoldersToChunks(
+        this.normalizeFolders(folders)
+      ).finally(() => {
+        this.foldersMigration = null
+      })
+    }
+
+    return this.foldersMigration
+  }
+
+  private async persistFoldersToChunks(
+    folders: BookmarksFolderStruct[]
+  ): Promise<void> {
+    const chunks = this.chunkFolders(folders)
+    const manifest: FoldersManifest = {
+      version: 1,
+      chunkKeys: chunks.map((_, index) => `${FOLDERS_CHUNK_PREFIX}${index}`)
+    }
+    const previous = await storageService.getValue<FoldersManifest>(
+      FOLDERS_MANIFEST_KEY,
+      null,
+      BOOKMARKS_STORAGE_AREA
+    )
+
+    const savedChunks = await Promise.all(
+      chunks.map((chunk, index) =>
+        storageService.setValue(
+          `${FOLDERS_CHUNK_PREFIX}${index}`,
+          chunk,
+          null,
+          BOOKMARKS_STORAGE_AREA
+        )
+      )
+    )
+    if (savedChunks.some((saved) => !saved)) {
+      throw new Error("Could not save bookmark folder chunks to sync storage")
+    }
+
+    await this.persistSynced(FOLDERS_MANIFEST_KEY, manifest)
+
+    const staleChunkKeys = (previous?.chunkKeys || []).filter(
+      (key) => !manifest.chunkKeys.includes(key)
+    )
+    await Promise.all(
+      staleChunkKeys.map((key) =>
+        storageService.deleteValue(key, null, BOOKMARKS_STORAGE_AREA)
+      )
+    )
+
+    await Promise.all([
+      storageService.deleteValue(FOLDERS_KEY),
+      storageService.deleteValue(
+        FOLDERS_KEY,
+        null,
+        BOOKMARKS_STORAGE_AREA
+      )
+    ])
+  }
+
+  private tradesManifestKey(folderId: string) {
+    return `${TRADES_MANIFEST_PREFIX}${folderId}`
+  }
+
+  private tradesChunkKey(folderId: string, index: number) {
+    return `${TRADES_CHUNK_PREFIX}${folderId}--${index}`
+  }
+
+  private getTradeFolderIdFromStorageKey(key: string): string | null {
+    const tradesPrefix = `${TRADES_PREFIX_KEY}--`
+    if (key.startsWith(tradesPrefix)) return key.slice(tradesPrefix.length)
+    if (key.startsWith(TRADES_MANIFEST_PREFIX)) {
+      return key.slice(TRADES_MANIFEST_PREFIX.length)
+    }
+    if (key.startsWith(TRADES_CHUNK_PREFIX)) {
+      const suffix = key.slice(TRADES_CHUNK_PREFIX.length)
+      return suffix.slice(0, suffix.lastIndexOf("--")) || null
+    }
+    return null
+  }
+
+  private async fetchTrades(folderId: string): Promise<BookmarksTradeStruct[]> {
+    const chunkedTrades = await this.fetchChunkedTrades(folderId)
+    if (chunkedTrades !== null) return chunkedTrades
+
+    const legacyTrades = await this.fetchSynced<BookmarksTradeStruct[]>(
+      `${TRADES_PREFIX_KEY}--${folderId}`
+    )
+    if (legacyTrades && legacyTrades.length > 0) {
+      await this.migrateTradesToChunks(folderId, legacyTrades)
+    }
+
+    return legacyTrades || []
+  }
+
+  private async fetchChunkedTrades(
+    folderId: string
+  ): Promise<BookmarksTradeStruct[] | null> {
+    const manifest = await storageService.getValue<FoldersManifest>(
+      this.tradesManifestKey(folderId),
+      null,
+      BOOKMARKS_STORAGE_AREA
+    )
+    if (
+      !manifest ||
+      manifest.version !== 1 ||
+      !Array.isArray(manifest.chunkKeys)
+    ) {
+      return null
+    }
+
+    const chunks = await Promise.all(
+      manifest.chunkKeys.map((key) =>
+        storageService.getValue<BookmarksTradeStruct[]>(
+          key,
+          null,
+          BOOKMARKS_STORAGE_AREA
+        )
+      )
+    )
+    if (chunks.some((chunk) => chunk === null)) return null
+
+    return chunks.flatMap((chunk) => chunk || [])
+  }
+
+  private chunkTrades(
+    folderId: string,
+    trades: BookmarksTradeStruct[]
+  ): BookmarksTradeStruct[][] {
+    const chunks: BookmarksTradeStruct[][] = []
+    let current: BookmarksTradeStruct[] = []
+
+    for (const trade of trades) {
+      const candidate = [...current, trade]
+      const key = this.tradesChunkKey(folderId, chunks.length)
+      if (
+        current.length > 0 &&
+        this.storagePayloadBytes(key, candidate) > FOLDERS_CHUNK_TARGET_BYTES
+      ) {
+        chunks.push(current)
+        current = [trade]
+      } else {
+        current = candidate
+      }
+
+      if (
+        this.storagePayloadBytes(
+          this.tradesChunkKey(folderId, chunks.length),
+          current
+        ) > 8192
+      ) {
+        throw new Error("A bookmarked trade is too large to synchronize")
+      }
+    }
+
+    if (current.length > 0) chunks.push(current)
+    return chunks
+  }
+
+  private async migrateTradesToChunks(
+    folderId: string,
+    trades: BookmarksTradeStruct[]
+  ): Promise<void> {
+    const migration = this.tradesMigrations.get(folderId)
+    if (migration) return migration
+
+    const nextMigration = this.persistTradesToChunks(folderId, trades).finally(
+      () => this.tradesMigrations.delete(folderId)
+    )
+    this.tradesMigrations.set(folderId, nextMigration)
+    return nextMigration
+  }
+
+  private async persistTradesToChunks(
+    folderId: string,
+    trades: BookmarksTradeStruct[]
+  ): Promise<void> {
+    const chunks = this.chunkTrades(folderId, trades)
+    const manifest: FoldersManifest = {
+      version: 1,
+      chunkKeys: chunks.map((_, index) => this.tradesChunkKey(folderId, index))
+    }
+    const manifestKey = this.tradesManifestKey(folderId)
+    const previous = await storageService.getValue<FoldersManifest>(
+      manifestKey,
+      null,
+      BOOKMARKS_STORAGE_AREA
+    )
+    const savedChunks = await Promise.all(
+      chunks.map((chunk, index) =>
+        storageService.setValue(
+          this.tradesChunkKey(folderId, index),
+          chunk,
+          null,
+          BOOKMARKS_STORAGE_AREA
+        )
+      )
+    )
+    if (savedChunks.some((saved) => !saved)) {
+      throw new Error("Could not save bookmarked trade chunks to sync storage")
+    }
+
+    await this.persistSynced(manifestKey, manifest)
+
+    const staleChunkKeys = (previous?.chunkKeys || []).filter(
+      (key) => !manifest.chunkKeys.includes(key)
+    )
+    await Promise.all(
+      staleChunkKeys.map((key) =>
+        storageService.deleteValue(key, null, BOOKMARKS_STORAGE_AREA)
+      )
+    )
+
+    await this.deleteSynced(`${TRADES_PREFIX_KEY}--${folderId}`)
+  }
+
+  private async deleteChunkedTrades(folderId: string): Promise<void> {
+    const manifestKey = this.tradesManifestKey(folderId)
+    const manifest = await storageService.getValue<FoldersManifest>(
+      manifestKey,
+      null,
+      BOOKMARKS_STORAGE_AREA
+    )
+    await Promise.all([
+      ...(manifest?.chunkKeys || []).map((key) =>
+        storageService.deleteValue(key, null, BOOKMARKS_STORAGE_AREA)
+      ),
+      storageService.deleteValue(manifestKey, null, BOOKMARKS_STORAGE_AREA),
+      storageService.deleteValue(manifestKey),
+      this.deleteSynced(`${TRADES_PREFIX_KEY}--${folderId}`)
+    ])
   }
 
   private normalizeFolders(
@@ -174,9 +499,7 @@ export class BookmarksService {
       }
     }
 
-    const request = this.fetchSynced<BookmarksTradeStruct[]>(
-      `${TRADES_PREFIX_KEY}--${folderId}`
-    )
+    const request = this.fetchTrades(folderId)
       .then((trades) => {
         const normalized = this.normalizeTrades(trades)
         this.tradesCache.set(folderId, normalized)
@@ -188,6 +511,12 @@ export class BookmarksService {
 
     this.tradesRequests.set(folderId, request)
     return request
+  }
+
+  private async refreshTradesFromStorage(folderId: string) {
+    const trades = await this.fetchTradesByFolderId(folderId, { force: true })
+    this.tradesCache.set(folderId, trades)
+    this.notifyChange({ tradesChanged: true, folderId })
   }
 
   private async fetchSynced<T>(key: string): Promise<T | null> {
@@ -307,7 +636,7 @@ export class BookmarksService {
   }
 
   async persistFolders(folders: BookmarksFolderStruct[]) {
-    await this.persistSynced(FOLDERS_KEY, folders)
+    await this.persistFoldersToChunks(folders)
   }
 
   async persistTrade(
@@ -336,10 +665,7 @@ export class BookmarksService {
       trades.map((t) => ({ ...t, id: t.id || uniqueId() }))
     )
     this.tradesCache.set(folderId, safeTrades)
-    await this.persistSynced(
-      `${TRADES_PREFIX_KEY}--${folderId}`,
-      safeTrades
-    )
+    await this.persistTradesToChunks(folderId, safeTrades)
     return [...safeTrades]
   }
 
@@ -360,7 +686,7 @@ export class BookmarksService {
     await this.persistFolders(updated)
     this.tradesCache.delete(folderId)
     this.tradesRequests.delete(folderId)
-    await this.deleteSynced(`${TRADES_PREFIX_KEY}--${folderId}`)
+    await this.deleteChunkedTrades(folderId)
     await this.refresh()
   }
 

--- a/lib/services/bookmarks.ts
+++ b/lib/services/bookmarks.ts
@@ -191,14 +191,33 @@ export class BookmarksService {
   }
 
   private async fetchSynced<T>(key: string): Promise<T | null> {
+    const local = await storageService.getValue<T>(key)
     const synced = await storageService.getValue<T>(
       key,
       null,
       BOOKMARKS_STORAGE_AREA
     )
+
+    if (this.hasStoredEntries(local) && !this.hasStoredEntries(synced)) {
+      const migrated = await storageService.setValue(
+        key,
+        local,
+        null,
+        BOOKMARKS_STORAGE_AREA
+      )
+      if (migrated) {
+        await storageService.deleteValue(key)
+      }
+      return local
+    }
+
     if (synced !== null) return synced
 
-    return storageService.getValue<T>(key)
+    return local
+  }
+
+  private hasStoredEntries(value: unknown): boolean {
+    return Array.isArray(value) ? value.length > 0 : value !== null
   }
 
   private async persistSynced(key: string, value: unknown): Promise<void> {

--- a/lib/services/bookmarks.ts
+++ b/lib/services/bookmarks.ts
@@ -11,10 +11,11 @@ import type { TradeSiteVersion } from "../types/trade-location"
 import { decodeBase64Utf8, encodeBase64Utf8 } from "../utilities/base64"
 import { uniqueId } from "../utilities/unique-id"
 import { languageStore, translate } from "./i18n"
-import { storageService } from "./storage"
+import { storageService, type StorageArea } from "./storage"
 
 const FOLDERS_KEY = "bookmark-folders"
 const TRADES_PREFIX_KEY = "bookmark-trades"
+const BOOKMARKS_STORAGE_AREA: StorageArea = "sync"
 const SECTION_DELIMITER = "\n--------------------\n"
 const LINE_DELIMITER = "\n"
 
@@ -80,7 +81,7 @@ export class BookmarksService {
     if (typeof chrome === "undefined" || !chrome.storage?.onChanged) return
 
     chrome.storage.onChanged.addListener((changes, areaName) => {
-      if (areaName !== "local") return
+      if (areaName !== BOOKMARKS_STORAGE_AREA) return
 
       const foldersChange = changes[FOLDERS_KEY]
       if (foldersChange) {
@@ -109,10 +110,9 @@ export class BookmarksService {
   // ─── STORAGE ──────────────────────────────────────────────
 
   async fetchFolders(): Promise<BookmarksFolderStruct[]> {
-    const folders =
-      await storageService.getValue<Partial<BookmarksFolderStruct>[]>(
-        FOLDERS_KEY
-      )
+    const folders = await this.fetchSynced<Partial<BookmarksFolderStruct>[]>(
+      FOLDERS_KEY
+    )
     return this.normalizeFolders(folders)
   }
 
@@ -174,8 +174,9 @@ export class BookmarksService {
       }
     }
 
-    const request = storageService
-      .getValue<BookmarksTradeStruct[]>(`${TRADES_PREFIX_KEY}--${folderId}`)
+    const request = this.fetchSynced<BookmarksTradeStruct[]>(
+      `${TRADES_PREFIX_KEY}--${folderId}`
+    )
       .then((trades) => {
         const normalized = this.normalizeTrades(trades)
         this.tradesCache.set(folderId, normalized)
@@ -187,6 +188,44 @@ export class BookmarksService {
 
     this.tradesRequests.set(folderId, request)
     return request
+  }
+
+  private async fetchSynced<T>(key: string): Promise<T | null> {
+    const synced = await storageService.getValue<T>(
+      key,
+      null,
+      BOOKMARKS_STORAGE_AREA
+    )
+    if (synced !== null) return synced
+
+    return storageService.getValue<T>(key)
+  }
+
+  private async persistSynced(key: string, value: unknown): Promise<void> {
+    const persisted = await storageService.setValue(
+      key,
+      value,
+      null,
+      BOOKMARKS_STORAGE_AREA
+    )
+    if (!persisted) {
+      throw new Error("Could not save bookmarks to browser sync storage")
+    }
+
+    await storageService.deleteValue(key)
+  }
+
+  private async deleteSynced(key: string): Promise<void> {
+    const deleted = await storageService.deleteValue(
+      key,
+      null,
+      BOOKMARKS_STORAGE_AREA
+    )
+    if (!deleted) {
+      throw new Error("Could not delete bookmarks from browser sync storage")
+    }
+
+    await storageService.deleteValue(key)
   }
 
   async fetchTradeByLocation(
@@ -249,7 +288,7 @@ export class BookmarksService {
   }
 
   async persistFolders(folders: BookmarksFolderStruct[]) {
-    await storageService.setValue(FOLDERS_KEY, folders)
+    await this.persistSynced(FOLDERS_KEY, folders)
   }
 
   async persistTrade(
@@ -278,7 +317,7 @@ export class BookmarksService {
       trades.map((t) => ({ ...t, id: t.id || uniqueId() }))
     )
     this.tradesCache.set(folderId, safeTrades)
-    await storageService.setValue(
+    await this.persistSynced(
       `${TRADES_PREFIX_KEY}--${folderId}`,
       safeTrades
     )
@@ -302,7 +341,7 @@ export class BookmarksService {
     await this.persistFolders(updated)
     this.tradesCache.delete(folderId)
     this.tradesRequests.delete(folderId)
-    await storageService.deleteValue(`${TRADES_PREFIX_KEY}--${folderId}`)
+    await this.deleteSynced(`${TRADES_PREFIX_KEY}--${folderId}`)
     await this.refresh()
   }
 

--- a/lib/services/extension-backup.ts
+++ b/lib/services/extension-backup.ts
@@ -48,10 +48,14 @@ const getAppVersion = () => {
 };
 
 const readAllStorage = async () => {
-  if (!hasValidExtensionContext() || !chrome.storage?.local) return {};
+  if (!hasValidExtensionContext() || !chrome.storage?.local || !chrome.storage?.sync) return {};
 
   try {
-    return await chrome.storage.local.get(null) as Record<string, StoragePayload>;
+    const [local, sync] = await Promise.all([
+      chrome.storage.local.get(null),
+      chrome.storage.sync.get(null)
+    ]);
+    return {...sync, ...local} as Record<string, StoragePayload>;
   } catch (error) {
     if (!isExtensionContextInvalidatedError(error)) {
       console.warn("[Poe Trade Plus] Backup storage read failed", error);
@@ -61,15 +65,24 @@ const readAllStorage = async () => {
 };
 
 const writeStorage = async (values: Record<string, StoragePayload>) => {
-  if (!hasValidExtensionContext() || !chrome.storage?.local) return false;
+  if (!hasValidExtensionContext() || !chrome.storage?.local || !chrome.storage?.sync) return false;
 
   try {
-    const current = await chrome.storage.local.get(null);
-    const keysToRemove = Object.keys(current).filter(isManagedStorageKey);
+    const [local, sync] = await Promise.all([
+      chrome.storage.local.get(null),
+      chrome.storage.sync.get(null)
+    ]);
+    const keysToRemove = [...new Set([
+      ...Object.keys(local),
+      ...Object.keys(sync)
+    ])].filter(isManagedStorageKey);
     if (keysToRemove.length > 0) {
-      await chrome.storage.local.remove(keysToRemove);
+      await Promise.all([
+        chrome.storage.local.remove(keysToRemove),
+        chrome.storage.sync.remove(keysToRemove)
+      ]);
     }
-    await chrome.storage.local.set(values);
+    await chrome.storage.sync.set(values);
     return true;
   } catch (error) {
     if (!isExtensionContextInvalidatedError(error)) {

--- a/lib/services/extension-backup.ts
+++ b/lib/services/extension-backup.ts
@@ -7,9 +7,15 @@ const STORAGE_KEYS = new Set([
   "app-settings",
   "app-settings-poe1",
   "app-settings-poe2",
-  "bookmark-folders"
+  "bookmark-folders",
+  "bookmark-folders-manifest"
 ]);
-const STORAGE_PREFIXES = ["bookmark-trades--"];
+const STORAGE_PREFIXES = [
+  "bookmark-trades--",
+  "bookmark-trades-manifest--",
+  "bookmark-trades-chunk--",
+  "bookmark-folders-chunk--"
+];
 const LOCAL_STORAGE_PREFIX = "bt-";
 const LOCAL_STORAGE_EXCLUDED_PREFIXES = [
   "bt-bulk-sellers-",

--- a/lib/services/i18n/de.ts
+++ b/lib/services/i18n/de.ts
@@ -5,6 +5,8 @@ export const germanTranslations: Record<string, TranslationValue> = {
   "whatsNew.item.mediumTextSizeTitle": "Mittlere Textgröße funktioniert korrekt",
   "whatsNew.item.mediumTextSizeDescription":
     "Die Auswahl von Mittel in den allgemeinen Einstellungen bleibt jetzt auch nach dem Neuladen der Erweiterung erhalten.",
+  "whatsNew.item.syncAcrossDevicesTitle": "Lesezeichen und Einstellungen zwischen Geräten synchronisieren",
+  "whatsNew.item.syncAcrossDevicesDescription": "Lesezeichen, Lesezeichenordner und Erweiterungseinstellungen folgen jetzt deinem angemeldeten Browserprofil. Bestehende Daten werden beim Update sicher migriert.",
   ...englishTranslations,
   "whatsNew.item.version1110Title": "Mehr Ordnersymbole und PoE2-Kopie wiederhergestellt",
   "whatsNew.item.version1110Description": "Ordnersymbole sind nach PoE1- und PoE2-Währungen sowie Aszendenzen organisiert; die Path-of-Building-Kopie ist wieder in PoE2-Ergebnissen verfügbar.",

--- a/lib/services/i18n/en.ts
+++ b/lib/services/i18n/en.ts
@@ -4,6 +4,8 @@ export const englishTranslations: Record<string, TranslationValue> = {
   "whatsNew.item.mediumTextSizeTitle": "Medium text size works correctly",
   "whatsNew.item.mediumTextSizeDescription":
     "Selecting Medium in General settings now keeps your preferred text size after the extension reloads.",
+  "whatsNew.item.syncAcrossDevicesTitle": "Sync bookmarks and settings across devices",
+  "whatsNew.item.syncAcrossDevicesDescription": "Bookmarks, bookmark folders, and extension settings now follow your signed-in browser profile. Existing data is safely migrated when you update.",
   "app.name": "Poe Trade Plus",
   "header.subtitle": "Trade Companion",
   "header.expandSidebar": "Expand Sidebar",

--- a/lib/services/i18n/es.ts
+++ b/lib/services/i18n/es.ts
@@ -4,6 +4,8 @@ export const spanishTranslations: Record<string, TranslationValue> = {
   "whatsNew.item.mediumTextSizeTitle": "El tamaño de texto Mediano funciona correctamente",
   "whatsNew.item.mediumTextSizeDescription":
     "Al seleccionar Mediano en los ajustes Generales, se conserva el tamaño de texto preferido tras recargar la extensión.",
+  "whatsNew.item.syncAcrossDevicesTitle": "Sincroniza marcadores y ajustes entre dispositivos",
+  "whatsNew.item.syncAcrossDevicesDescription": "Los marcadores, las carpetas de marcadores y los ajustes de la extensión ahora siguen el perfil con el que iniciaste sesión en el navegador. Tus datos existentes se migran de forma segura al actualizar.",
   "app.name": "Poe Trade Plus",
   "header.subtitle": "Compañero de Trade",
   "header.expandSidebar": "Expandir panel",

--- a/lib/services/i18n/fr.ts
+++ b/lib/services/i18n/fr.ts
@@ -5,6 +5,8 @@ export const frenchTranslations: Record<string, TranslationValue> = {
   "whatsNew.item.mediumTextSizeTitle": "La taille de texte moyenne fonctionne correctement",
   "whatsNew.item.mediumTextSizeDescription":
     "Sélectionner Moyenne dans les paramètres généraux conserve désormais votre taille de texte après le rechargement de l’extension.",
+  "whatsNew.item.syncAcrossDevicesTitle": "Synchronisez vos marque-pages et réglages entre appareils",
+  "whatsNew.item.syncAcrossDevicesDescription": "Les marque-pages, leurs dossiers et les réglages de l’extension suivent désormais votre profil de navigateur connecté. Les données existantes sont migrées en toute sécurité lors de la mise à jour.",
   ...englishTranslations,
   "whatsNew.item.version1110Title": "Plus d’icônes de dossier et copie PoE2 restaurée",
   "whatsNew.item.version1110Description": "Les icônes de dossier sont organisées par monnaies et ascendances PoE1 et PoE2, et la copie Path of Building est de nouveau disponible dans les résultats PoE2.",

--- a/lib/services/i18n/ja.ts
+++ b/lib/services/i18n/ja.ts
@@ -5,6 +5,8 @@ export const japaneseTranslations: Record<string, TranslationValue> = {
   "whatsNew.item.mediumTextSizeTitle": "中サイズの文字が正しく機能するようになりました",
   "whatsNew.item.mediumTextSizeDescription":
     "一般設定で中を選択すると、拡張機能を再読み込みした後も文字サイズの設定が保持されます。",
+  "whatsNew.item.syncAcrossDevicesTitle": "ブックマークと設定をデバイス間で同期",
+  "whatsNew.item.syncAcrossDevicesDescription": "ブックマーク、ブックマークフォルダー、拡張機能の設定が、ログイン中のブラウザプロフィールに同期されるようになりました。既存のデータは更新時に安全に移行されます。",
   ...englishTranslations,
   "whatsNew.item.version1110Title": "フォルダーアイコンの拡充と PoE2 コピーの復元",
   "whatsNew.item.version1110Description": "フォルダーアイコンを PoE1 と PoE2 の通貨・アセンダンシーごとに整理し、Path of Building 用コピーを PoE2 の結果で再び利用できるようにしました。",

--- a/lib/services/i18n/ko.ts
+++ b/lib/services/i18n/ko.ts
@@ -5,6 +5,8 @@ export const koreanTranslations: Record<string, TranslationValue> = {
   "whatsNew.item.mediumTextSizeTitle": "중간 텍스트 크기가 올바르게 작동합니다",
   "whatsNew.item.mediumTextSizeDescription":
     "일반 설정에서 중간을 선택하면 확장 프로그램을 다시 로드한 후에도 텍스트 크기 설정이 유지됩니다.",
+  "whatsNew.item.syncAcrossDevicesTitle": "기기 간 북마크와 설정 동기화",
+  "whatsNew.item.syncAcrossDevicesDescription": "북마크, 북마크 폴더 및 확장 프로그램 설정이 이제 로그인한 브라우저 프로필을 따라 동기화됩니다. 기존 데이터는 업데이트 시 안전하게 마이그레이션됩니다.",
   ...englishTranslations,
   "whatsNew.item.version1110Title": "폴더 아이콘 확장 및 PoE2 복사 복원",
   "whatsNew.item.version1110Description": "폴더 아이콘을 PoE1 및 PoE2 화폐와 전직별로 정리했고, Path of Building용 복사를 PoE2 결과에서 다시 사용할 수 있습니다.",

--- a/lib/services/i18n/pt.ts
+++ b/lib/services/i18n/pt.ts
@@ -5,6 +5,8 @@ export const portugueseTranslations: Record<string, TranslationValue> = {
   "whatsNew.item.mediumTextSizeTitle": "O tamanho de texto Médio funciona corretamente",
   "whatsNew.item.mediumTextSizeDescription":
     "Selecionar Médio nas configurações Gerais agora mantém o tamanho de texto preferido depois que a extensão é recarregada.",
+  "whatsNew.item.syncAcrossDevicesTitle": "Sincronize favoritos e configurações entre dispositivos",
+  "whatsNew.item.syncAcrossDevicesDescription": "Os favoritos, as pastas de favoritos e as configurações da extensão agora acompanham o perfil conectado no navegador. Os dados existentes são migrados com segurança ao atualizar.",
   ...englishTranslations,
   "whatsNew.item.version1110Title": "Mais ícones de pasta e cópia PoE2 restaurada",
   "whatsNew.item.version1110Description": "Os ícones de pasta são organizados por moedas e ascendências de PoE1 e PoE2, e a cópia para Path of Building voltou aos resultados de PoE2.",

--- a/lib/services/i18n/ru.ts
+++ b/lib/services/i18n/ru.ts
@@ -5,6 +5,8 @@ export const russianTranslations: Record<string, TranslationValue> = {
   "whatsNew.item.mediumTextSizeTitle": "Средний размер текста работает корректно",
   "whatsNew.item.mediumTextSizeDescription":
     "Выбор среднего размера в общих настройках теперь сохраняется после перезагрузки расширения.",
+  "whatsNew.item.syncAcrossDevicesTitle": "Синхронизация закладок и настроек между устройствами",
+  "whatsNew.item.syncAcrossDevicesDescription": "Закладки, папки закладок и настройки расширения теперь следуют за профилем браузера, в который выполнен вход. Существующие данные безопасно переносятся при обновлении.",
   ...englishTranslations,
   "whatsNew.item.version1110Title": "Больше иконок папок и восстановленная копия PoE2",
   "whatsNew.item.version1110Description": "Иконки папок упорядочены по валютам и возвышениям PoE1 и PoE2, а копирование для Path of Building снова доступно в результатах PoE2.",

--- a/lib/services/i18n/th.ts
+++ b/lib/services/i18n/th.ts
@@ -5,6 +5,8 @@ export const thaiTranslations: Record<string, TranslationValue> = {
   "whatsNew.item.mediumTextSizeTitle": "ขนาดข้อความปานกลางทำงานได้ถูกต้อง",
   "whatsNew.item.mediumTextSizeDescription":
     "การเลือกขนาดปานกลางในการตั้งค่าทั่วไปจะคงขนาดข้อความที่ต้องการไว้หลังจากโหลดส่วนขยายใหม่.",
+  "whatsNew.item.syncAcrossDevicesTitle": "ซิงค์บุ๊กมาร์กและการตั้งค่าระหว่างอุปกรณ์",
+  "whatsNew.item.syncAcrossDevicesDescription": "บุ๊กมาร์ก โฟลเดอร์บุ๊กมาร์ก และการตั้งค่าส่วนขยายจะติดตามโปรไฟล์เบราว์เซอร์ที่คุณลงชื่อเข้าใช้ ข้อมูลเดิมจะถูกย้ายอย่างปลอดภัยเมื่ออัปเดต",
   ...englishTranslations,
   "whatsNew.item.version1110Title": "เพิ่มไอคอนโฟลเดอร์และคืนค่าการคัดลอก PoE2",
   "whatsNew.item.version1110Description": "ไอคอนโฟลเดอร์จัดตามสกุลเงินและสายอาชีพ PoE1 และ PoE2 และการคัดลอกสำหรับ Path of Building กลับมาใช้ได้ในผลลัพธ์ PoE2.",

--- a/lib/services/settings.ts
+++ b/lib/services/settings.ts
@@ -2,7 +2,7 @@ import { writable } from "svelte/store"
 
 import type { TradeSiteVersion } from "../types/trade-location"
 import { setLanguage, type AppLanguage } from "./i18n"
-import { storageService } from "./storage"
+import { storageService, type StorageArea } from "./storage"
 
 export type SidebarSide = "left" | "right"
 export type BookmarkTradeActionId =
@@ -54,6 +54,7 @@ interface GlobalSettings {
 }
 
 const GLOBAL_SETTINGS_KEY = "app-settings"
+const SETTINGS_STORAGE_AREA: StorageArea = "sync"
 export const DEFAULT_SIDEBAR_WIDTH = 450
 const versionSettingsKey = (version: TradeSiteVersion) =>
   `app-settings-poe${version}`
@@ -90,6 +91,21 @@ function normalizeTextSize(textSize: unknown): TextSizePreference {
     : DEFAULT_TEXT_SIZE
 }
 
+function getStorageChangeValue<T>(
+  change: chrome.storage.StorageChange | undefined
+): T | undefined {
+  const payload = change?.newValue
+  if (
+    typeof payload !== "object" ||
+    payload === null ||
+    !("value" in payload)
+  ) {
+    return undefined
+  }
+
+  return payload.value as T
+}
+
 let activeVersion: TradeSiteVersion = inferTradeVersion()
 let globalSettings: GlobalSettings = DEFAULT_GLOBAL_SETTINGS
 let activeVersionSettings: VersionSettings = DEFAULT_VERSION_SETTINGS
@@ -101,6 +117,17 @@ let currentSettings: AppSettings = combineSettings(
 let versionRequestId = 0
 
 const { subscribe, set } = writable<AppSettings>(currentSettings)
+
+function normalizeGlobalSettings(
+  value?: Partial<AppSettings> | null
+): GlobalSettings {
+  return {
+    sidebarSide: value?.sidebarSide ?? DEFAULT_GLOBAL_SETTINGS.sidebarSide,
+    sidebarWidth: value?.sidebarWidth ?? DEFAULT_GLOBAL_SETTINGS.sidebarWidth,
+    language: value?.language ?? DEFAULT_GLOBAL_SETTINGS.language,
+    textSize: normalizeTextSize(value?.textSize)
+  }
+}
 
 function inferTradeVersion(): TradeSiteVersion {
   if (typeof window === "undefined") return "1"
@@ -192,6 +219,74 @@ function publish() {
   set(currentSettings)
 }
 
+function bindStorageSync() {
+  if (typeof chrome === "undefined" || !chrome.storage?.onChanged) return
+
+  chrome.storage.onChanged.addListener((changes, areaName) => {
+    if (areaName !== SETTINGS_STORAGE_AREA) return
+
+    const globalChange = changes[GLOBAL_SETTINGS_KEY]
+    if (globalChange) {
+      globalSettings = normalizeGlobalSettings(
+        getStorageChangeValue<Partial<AppSettings>>(globalChange)
+      )
+      setLanguage(globalSettings.language)
+      publish()
+    }
+
+    for (const version of ["1", "2"] as const) {
+      const change = changes[versionSettingsKey(version)]
+      if (!change) continue
+
+      const next = normalizeVersionSettings(
+        getStorageChangeValue<Partial<VersionSettings>>(change)
+      )
+      versionCache.set(version, next)
+      if (version === activeVersion) {
+        activeVersionSettings = next
+        publish()
+      }
+    }
+  })
+}
+
+async function fetchSynced<T>(key: string): Promise<T | null> {
+  const local = await storageService.getValue<T>(key)
+  const synced = await storageService.getValue<T>(
+    key,
+    null,
+    SETTINGS_STORAGE_AREA
+  )
+  if (synced !== null) return synced
+
+  if (local === null) return null
+
+  const migrated = await storageService.setValue(
+    key,
+    local,
+    null,
+    SETTINGS_STORAGE_AREA
+  )
+  if (migrated) {
+    await storageService.deleteValue(key)
+  }
+
+  return local
+}
+
+async function persistSynced(key: string, value: unknown): Promise<boolean> {
+  const persisted = await storageService.setValue(
+    key,
+    value,
+    null,
+    SETTINGS_STORAGE_AREA
+  )
+  if (!persisted) return false
+
+  await storageService.deleteValue(key)
+  return true
+}
+
 async function loadVersionSettings(
   version: TradeSiteVersion,
   legacy?: Partial<AppSettings> | null
@@ -199,7 +294,7 @@ async function loadVersionSettings(
   const cached = versionCache.get(version)
   if (cached) return cached
 
-  const stored = await storageService.getValue<VersionSettings>(
+  const stored = await fetchSynced<VersionSettings>(
     versionSettingsKey(version)
   )
   const next = stored
@@ -209,7 +304,7 @@ async function loadVersionSettings(
   versionCache.set(version, next)
 
   if (!stored) {
-    await storageService.setValue(versionSettingsKey(version), next)
+    await persistSynced(versionSettingsKey(version), next)
   }
 
   return next
@@ -218,15 +313,9 @@ async function loadVersionSettings(
 async function load() {
   const requestedVersion = inferTradeVersion()
   const requestId = ++versionRequestId
-  const stored =
-    await storageService.getValue<Partial<AppSettings>>(GLOBAL_SETTINGS_KEY)
+  const stored = await fetchSynced<Partial<AppSettings>>(GLOBAL_SETTINGS_KEY)
 
-  globalSettings = {
-    sidebarSide: stored?.sidebarSide ?? DEFAULT_GLOBAL_SETTINGS.sidebarSide,
-    sidebarWidth: stored?.sidebarWidth ?? DEFAULT_GLOBAL_SETTINGS.sidebarWidth,
-    language: stored?.language ?? DEFAULT_GLOBAL_SETTINGS.language,
-    textSize: normalizeTextSize(stored?.textSize)
-  }
+  globalSettings = normalizeGlobalSettings(stored)
 
   const [poe1Settings, poe2Settings] = await Promise.all([
     loadVersionSettings("1", stored),
@@ -241,7 +330,7 @@ async function load() {
 }
 
 async function saveGlobal(next: GlobalSettings) {
-  const saved = await storageService.setValue(GLOBAL_SETTINGS_KEY, next)
+  const saved = await persistSynced(GLOBAL_SETTINGS_KEY, next)
   if (!saved) {
     console.warn("[Poe Trade Plus] Failed to persist global settings")
     return false
@@ -253,7 +342,7 @@ async function saveGlobal(next: GlobalSettings) {
 }
 
 async function saveVersion(next: VersionSettings) {
-  const saved = await storageService.setValue(
+  const saved = await persistSynced(
     versionSettingsKey(activeVersion),
     next
   )
@@ -269,6 +358,8 @@ async function saveVersion(next: VersionSettings) {
   publish()
   return true
 }
+
+bindStorageSync()
 
 export const settings = {
   subscribe,

--- a/lib/services/storage.ts
+++ b/lib/services/storage.ts
@@ -8,6 +8,8 @@ interface StoragePayload {
   expiresAt: string | null
 }
 
+export type StorageArea = "local" | "sync"
+
 const isStoragePayload = (value: unknown): value is StoragePayload =>
   typeof value === "object" &&
   value !== null &&
@@ -26,12 +28,13 @@ export class StorageService {
   async setValue(
     key: string,
     value: unknown,
-    league: string | null = null
+    league: string | null = null,
+    area: StorageArea = "local"
   ): Promise<boolean> {
     return this.write(this.formatKey(key, league), {
       expiresAt: null,
       value
-    })
+    }, area)
   }
 
   async setEphemeralValue(
@@ -48,9 +51,10 @@ export class StorageService {
 
   async getValue<T>(
     key: string,
-    league: string | null = null
+    league: string | null = null,
+    area: StorageArea = "local"
   ): Promise<T | null> {
-    const payload = await this.read(this.formatKey(key, league))
+    const payload = await this.read(this.formatKey(key, league), area)
     if (!payload) return null
 
     const { expiresAt, value } = payload
@@ -72,13 +76,22 @@ export class StorageService {
     return (league ? `${key}--${league}` : key).toLowerCase()
   }
 
-  private async read(key: string): Promise<StoragePayload | null> {
-    if (!hasValidExtensionContext() || !chrome.storage?.local) {
+  private getStorageArea(area: StorageArea): chrome.storage.StorageArea | null {
+    if (!hasValidExtensionContext() || !chrome.storage?.[area]) {
       console.warn("Storage not available")
       return null
     }
+    return chrome.storage[area]
+  }
+
+  private async read(
+    key: string,
+    area: StorageArea = "local"
+  ): Promise<StoragePayload | null> {
+    const storageArea = this.getStorageArea(area)
+    if (!storageArea) return null
     try {
-      const result = await chrome.storage.local.get([key])
+      const result = await storageArea.get([key])
       const payload = result[key]
       return isStoragePayload(payload) ? payload : null
     } catch (error) {
@@ -91,9 +104,10 @@ export class StorageService {
 
   async deleteValue(
     key: string,
-    league: string | null = null
+    league: string | null = null,
+    area: StorageArea = "local"
   ): Promise<boolean> {
-    return this.remove(this.formatKey(key, league))
+    return this.remove(this.formatKey(key, league), area)
   }
 
   setLocalValue(key: string, value: string, league: string | null = null) {
@@ -108,13 +122,15 @@ export class StorageService {
     window.localStorage.removeItem(`bt-${this.formatKey(key, league)}`)
   }
 
-  private async write(key: string, value: StoragePayload): Promise<boolean> {
-    if (!hasValidExtensionContext() || !chrome.storage?.local) {
-      console.warn("Storage not available")
-      return false
-    }
+  private async write(
+    key: string,
+    value: StoragePayload,
+    area: StorageArea = "local"
+  ): Promise<boolean> {
+    const storageArea = this.getStorageArea(area)
+    if (!storageArea) return false
     try {
-      await chrome.storage.local.set({ [key]: value })
+      await storageArea.set({ [key]: value })
       return true
     } catch (error) {
       if (!isExtensionContextInvalidatedError(error)) {
@@ -124,13 +140,14 @@ export class StorageService {
     }
   }
 
-  private async remove(keys: string | string[]): Promise<boolean> {
-    if (!hasValidExtensionContext() || !chrome.storage?.local) {
-      console.warn("Storage not available")
-      return false
-    }
+  private async remove(
+    keys: string | string[],
+    area: StorageArea = "local"
+  ): Promise<boolean> {
+    const storageArea = this.getStorageArea(area)
+    if (!storageArea) return false
     try {
-      await chrome.storage.local.remove(keys)
+      await storageArea.remove(keys)
       return true
     } catch (error) {
       if (!isExtensionContextInvalidatedError(error)) {

--- a/lib/services/storage.ts
+++ b/lib/services/storage.ts
@@ -10,12 +10,144 @@ interface StoragePayload {
 
 export type StorageArea = "local" | "sync"
 
+const SYNC_VALUE_FORMAT = 1
+const COMPRESSED_SYNC_VALUE_FORMAT = 2
+const COMPACT_KEYS: Record<string, string> = {
+  id: "i",
+  title: "t",
+  location: "l",
+  version: "v",
+  type: "y",
+  slug: "s",
+  league: "g",
+  completedAt: "d",
+  categoryId: "c",
+  categories: "a",
+  icon: "o",
+  archivedAt: "r",
+  sidebarSide: "S",
+  sidebarWidth: "W",
+  language: "L",
+  textSize: "T",
+  showEquivalentPricing: "e",
+  showMagebloodLegacyDescriptions: "m",
+  showBulkSellers: "b",
+  showHistory: "h",
+  showFinerFilters: "f",
+  showQuickFilters: "q",
+  quickFiltersPlacement: "p",
+  compactActionsMenu: "A",
+  ultraCompactBookmarks: "u",
+  classicBookmarkTradeActions: "C",
+  compactBookmarkTradeActions: "B",
+  ultraCompactBookmarkTradeActions: "U",
+  bookmarkCategoriesEnabled: "k",
+  chunkKeys: "K",
+  expiresAt: "x",
+  value: "V"
+}
+const EXPANDED_KEYS = Object.fromEntries(
+  Object.entries(COMPACT_KEYS).map(([key, compact]) => [compact, key])
+)
+
 const isStoragePayload = (value: unknown): value is StoragePayload =>
   typeof value === "object" &&
   value !== null &&
   "value" in value &&
   "expiresAt" in value &&
   (typeof value.expiresAt === "string" || value.expiresAt === null)
+
+const compactSyncValue = (value: unknown): unknown => {
+  if (Array.isArray(value)) return value.map(compactSyncValue)
+  if (typeof value !== "object" || value === null) return value
+
+  return Object.fromEntries(
+    Object.entries(value).map(([key, entry]) => [
+      COMPACT_KEYS[key] || key,
+      compactSyncValue(entry)
+    ])
+  )
+}
+
+const expandSyncValue = (value: unknown): unknown => {
+  if (Array.isArray(value)) return value.map(expandSyncValue)
+  if (typeof value !== "object" || value === null) return value
+
+  return Object.fromEntries(
+    Object.entries(value).map(([key, entry]) => [
+      EXPANDED_KEYS[key] || key,
+      expandSyncValue(entry)
+    ])
+  )
+}
+
+const isEncodedSyncValue = (value: unknown): value is [number, unknown] =>
+  Array.isArray(value) &&
+  value.length === 2 &&
+  (value[0] === SYNC_VALUE_FORMAT || value[0] === COMPRESSED_SYNC_VALUE_FORMAT)
+
+const isCompressedSyncValue = (value: unknown): value is [number, string] =>
+  Array.isArray(value) &&
+  value.length === 2 &&
+  value[0] === COMPRESSED_SYNC_VALUE_FORMAT &&
+  typeof value[1] === "string"
+
+const bytesToBase64 = (bytes: Uint8Array) => {
+  let binary = ""
+  for (const byte of bytes) binary += String.fromCharCode(byte)
+  return btoa(binary)
+}
+
+const base64ToBytes = (value: string) =>
+  Uint8Array.from(atob(value), (character) => character.charCodeAt(0))
+
+const gzip = async (value: string) => {
+  const stream = new Blob([value])
+    .stream()
+    .pipeThrough(new CompressionStream("gzip"))
+  return new Uint8Array(await new Response(stream).arrayBuffer())
+}
+
+const gunzip = async (value: Uint8Array) => {
+  const stream = new Blob([new Uint8Array(value).buffer])
+    .stream()
+    .pipeThrough(new DecompressionStream("gzip"))
+  return new Response(stream).text()
+}
+
+const encodeSyncValue = async (value: unknown): Promise<[number, unknown]> => {
+  const compact = compactSyncValue(value)
+  const compactValue: [number, unknown] = [SYNC_VALUE_FORMAT, compact]
+
+  if (
+    typeof CompressionStream === "undefined" ||
+    typeof DecompressionStream === "undefined" ||
+    typeof btoa === "undefined"
+  ) {
+    return compactValue
+  }
+
+  try {
+    const compressedValue: [number, string] = [
+      COMPRESSED_SYNC_VALUE_FORMAT,
+      bytesToBase64(await gzip(JSON.stringify(compact)))
+    ]
+    return JSON.stringify(compressedValue).length <
+      JSON.stringify(compactValue).length
+      ? compressedValue
+      : compactValue
+  } catch {
+    return compactValue
+  }
+}
+
+const decodeSyncValue = async (value: unknown): Promise<unknown> => {
+  if (isCompressedSyncValue(value)) {
+    return expandSyncValue(JSON.parse(await gunzip(base64ToBytes(value[1]))))
+  }
+
+  return isEncodedSyncValue(value) ? expandSyncValue(value[1]) : value
+}
 
 export class StorageService {
   private static instance: StorageService
@@ -93,7 +225,25 @@ export class StorageService {
     try {
       const result = await storageArea.get([key])
       const payload = result[key]
-      return isStoragePayload(payload) ? payload : null
+      if (!isStoragePayload(payload)) return null
+
+      if (area !== "sync") return payload
+
+      const value = await decodeSyncValue(payload.value)
+      if (!isCompressedSyncValue(payload.value)) {
+        const encodedValue = await encodeSyncValue(value)
+        if (JSON.stringify(encodedValue) === JSON.stringify(payload.value)) {
+          return { ...payload, value }
+        }
+        await storageArea.set({
+          [key]: {
+            ...payload,
+            value: encodedValue
+          }
+        })
+      }
+
+      return { ...payload, value }
     } catch (error) {
       if (!isExtensionContextInvalidatedError(error)) {
         console.warn("Storage read failed", error)
@@ -130,7 +280,12 @@ export class StorageService {
     const storageArea = this.getStorageArea(area)
     if (!storageArea) return false
     try {
-      await storageArea.set({ [key]: value })
+      const storedValue =
+        area === "sync" ? await encodeSyncValue(value.value) : value
+      await storageArea.set({
+        [key]:
+          area === "sync" ? { ...value, value: storedValue } : value
+      })
       return true
     } catch (error) {
       if (!isExtensionContextInvalidatedError(error)) {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "poe-trade-plus",
   "displayName": "Poe Trade Plus",
-  "version": "1.1.16",
+  "version": "1.1.17",
   "packageManager": "pnpm@11.3.0",
   "license": "MIT",
   "description": "Poe Trade Plus enhances the Path of Exile trade site with bookmarks, history and result tools.",


### PR DESCRIPTION
# v1.1.17

## 1.1.17
### New features
- **Sync bookmarks and settings across devices** — Bookmarks, bookmark folders, and extension settings now follow your signed-in browser profile. Existing data is safely migrated when you update.

## 1.1.16
### Fixes
- **Medium text size works correctly** — Selecting Medium in General settings now keeps your preferred text size after the extension reloads.

## 1.1.14
### New features
- **Middle-click folders to open saved searches** — Middle-click a bookmark folder to open all its saved searches in background tabs.

## 1.1.13
### New features
- **Kakao Games trade site support** — The sidebar and trade helpers now work on poe.kakaogames.com for both PoE1 (/trade) and PoE2 (/trade2).

## 1.1.12
### Fixes
- **Middle-click no longer enables auto-scroll** — Middle-clicking a saved search opens it in a background tab without activating the browser's auto-scroll cursor.

## 1.1.11
### New features
- **Guided tutorial refreshed** — The tutorial now follows the main workflows, groups related settings together, and keeps its guide cards out of the way of the controls they explain.
- **Bookmark Layout preview matches the real list** — The live preview now uses the real folder and bookmark components, including categories, two example searches, and the layout-specific action placement.

## 1.1.10
### New features
- **Open saved searches in new tabs** — Middle-click a saved search to open it in a background tab, so you can queue several searches without leaving the current one.
- **Bookmark icons are easier to browse** — The folder icon picker now groups currency and ascendancy icons, making the right icon faster to find.
- **Sidebar preferences are more reliable** — Sidebar defaults are shared consistently, and the Path of Building copy action remains visible where it is available on PoE2.

## 1.1.9
### Fixes
- **Bookmarks update more reliably** — Saved bookmark changes now validate stored data before updating the sidebar, preventing malformed or outdated storage entries from causing problems.
- **Cleaner Bookmark Layout preview** — The live Bookmark Layout preview no longer shows a league label, keeping the sample focused on the layout and actions.

## 1.1.8
### New features
- **Optional desecrated mods in Craft of Exile exports** — Craft of Exile exports now exclude desecrated mods by default. You can opt in from Results settings to include them as normal modifiers, with a warning that Craft of Exile does not yet support importing them.

## 1.1.7
### New features
- **Bookmarks follow active trade realm** — Saved searches now open in the active trade tab's current league and realm, while keeping their saved league as a fallback.
- **Clear Buyout Price shortcut** — Quick Filter Presets now include a Clear button that resets Buyout Price to Chaos Orb Equivalent and works with supported trade-site languages.

## 1.1.6
### New features
- **Wiki button for unique items** — Results can now show an optional W action on unique items that opens the matching PoE Wiki or PoE2 Wiki page.
- **Minimal bookmark layout** — Bookmarks now offer Classic, Compact, and Minimal layouts. Minimal keeps rows dense without changing the Path of Exile look.
- **Actions saved per layout** — Choose visible bookmark actions independently for Classic, Compact, and Minimal. Settings and preview update together.

## 1.1.5
### New features
- **Bookmark categories inside folders** — Saved searches can now be grouped into optional categories inside each bookmark folder. The feature is off by default, and turning it off returns every bookmark to the main folder list.
- **Cleaner bookmark action menus** — Category assignment, category creation, and category deletion now live inside the bookmark action menu, with inline creation and the same delete confirmation modal used elsewhere.

### Polish
- **Settings are more compact** — Long setting descriptions now appear as hover help, reducing visual clutter while keeping the details available when you need them.
- **General settings are clearer** — The Interface tab is now General, and Backup & Restore lives there alongside the other extension-wide options.

## 1.1.4
### New features
- **Adjustable text size** — Interface settings now include Small, Medium, Large, and Extra text sizes, with Large as the default.
- **Tutorial access moved to About** — The button to reopen the onboarding tutorial now lives in About, keeping Interface settings focused on display and language options.

## 1.1.3
### New features
- **Full extension backup** — Backup files now include saved folders, searches, global settings, PoE1/PoE2 result settings, and extension preferences in one portable JSON file.
- **Old folder backups still restore** — The restore action still accepts older folder-only .txt exports, so existing backups remain usable.

## 1.1.2
### New features
- **External reference links in the popup** — The popup can now show grouped PoE1 and PoE2 shortcuts for the official trade-adjacent tools, including the Path of Exile Wiki, Path of Exile 2 Wiki, Path of Regex, Craft of Exile, PoEDb, PoE2Db, and poe.ninja.
- **New PoE2 bookmark folder icons** — Disciple of Varashta, Martial Artist, and Spirit Walker icons are available for PoE2 bookmark folders.
- **Mageblood Legacy descriptions for PoE2** — A new Results setting can show hidden Mageblood Legacy effects below PoE2 item results, including duplicate Legacy scaling.

### Fixes
- **Localized PoE2 trade links load correctly** — Bookmarks and helper panels now recognize localized trade2 hosts such as es.pathofexile.com and keep league URLs with spaces encoded correctly.
- **Mageblood Legacy works across languages** — Legacy detection now uses stable trade stat ids, with localized effect descriptions for English, Spanish, Portuguese, Russian, Thai, German, French, Japanese, and Korean.

### Polish
- **Mageblood details stay quiet until hover** — Legacy descriptions show the final value by default, while base value and duplicate effect details appear inline on hover.
- **Mageblood descriptions match item layout** — Legacy description blocks now sit below corrupt/explicit separators like native notable descriptions and stay out of copied item text.

## 1.1.1
### Fixes
- **Foulborn items add the correct modifier** — Quick filter buttons now compensate for mutated Foulborn item rows where the trade site shifts modifier stat ids out of visual order.
- **Bookmark action buttons no longer open searches** — Editing, refreshing, duplicating, or opening the bookmark menu stays inside that action instead of triggering the saved search row.
- **PoE2 copy stays out of PoE1** — The Path of Building copy option is now only shown on the PoE2 trade site.
- **Craft of Exile buttons keep their shape** — The CoE action button is now a centered 30px square so it aligns cleanly with the result row controls.

### Polish
- **Craft of Exile copy avoids unsupported modifier slots** — Items with Prefix/Suffix Modifier allowed affixes now show a greyed CoE button with an explanation, while Copy for PoB keeps working.
- **Version-specific settings are clearer** — PoE1 and PoE2 can keep separate result-tool preferences where that matters, and PoE2-only tools stay hidden on PoE1.

## 1.1.0
### New features
- **Settings are now easier to navigate** — Customization is grouped into Interface, Sidebar, Results, and Bookmarks so each option has a clearer home.
- **Bookmark Layout now has a live preview** — The Bookmarks settings tab shows a real-time saved-search preview using the same action menu as the actual bookmark list.
- **What's New is now built into the sidebar** — New releases can show a compact update prompt, plus a full release notes modal from About.
- **Quick Filter Presets can live where you work** — Enable them from Results settings, then choose whether they appear in the sidebar or directly above the trade site's Stat Filters.
- **Craft of Exile export is easier to reach** — PoE1 and PoE2 result rows can now expose a CoE action that copies items in Craft of Exile's advanced import format.
- **PoE2 copy support for Path of Building** — A dedicated PoE2 copy option can surface beside other result actions and copy item text ready for PoB.
- **Equivalent pricing works across both games** — poe.ninja ratios now support PoE1 and PoE2 so chaos/divine conversion stays useful on either trade site.

### Polish
- **Sidebar and result options were separated** — Visible sidebar modules now live under Sidebar, while injected trade-result tools stay under Results.
- **Add To Filters moved out of the sidebar by default** — Quick filter presets can now be injected into the trade page, keeping the sidebar focused on navigation and saved searches.
- **Bookmark folders remember their open state** — Expanded and collapsed folders persist more predictably across sessions.
- **History labels and trade URLs are cleaner** — League names, fallbacks, and trade-link handling received small consistency improvements.
- **Result cards are easier to use** — Card click handling and seller panel accessibility were tightened for repeated trade workflows.

### Fixes
- **More reliable background messaging** — Background requests and bulk seller caching now handle failure cases more defensively.
- **Finer Filters hover behavior is smoother** — Compact result layouts and item filter buttons now behave more consistently.
- **Bookmark text opens saved searches again** — Clicking the saved-search title now opens the bookmark instead of being ignored.
- **Extension dependencies were hardened** — Dependency overrides and validation changes reduce known package and request risks.
