### PR TITLE
Release v1.1.18

### DIFF
--- a/Chrome.md
+++ b/Chrome.md
@@ -1,45 +1,60 @@
 🎯 KEY FEATURES:
 
 📌 BOOKMARK MANAGEMENT
-• Organize searches into PoE1/PoE2 version-aware folders
-• Create, rename, archive, duplicate, and reorder saved searches instantly
-• Drag-and-drop folders and bookmarks for faster organization
+• Organize saved searches into PoE1/PoE2 version-aware folders
+• Create, rename, archive, duplicate, and reorder folders or saved searches instantly
+• Drag and drop folders and bookmarks for fast organization
+• Group saved searches into optional categories inside each folder
+• Choose Classic, Compact, or Minimal bookmark layouts, with actions configured per layout
+• Open one saved search or a whole folder in background tabs with middle-click
+• Saved searches follow the active trade tab's realm and league, with the original league kept as a fallback
+• Browse grouped PoE1 and PoE2 folder icons for currencies, classes, ascendancies, and more
 • Import/export individual folders as portable backup strings
-• Full extension backup and restore with folders, searches, settings, and preferences
-• Legacy folder-only .txt backups are still supported
-• PoE2-themed folder icons for currencies, classes, ascendancies, and more
+• Full extension backup and restore for folders, searches, settings, and preferences
+• Restore legacy folder-only .txt backups
 
 ⏱️ SEARCH HISTORY
-• Automatic tracking of visited trade searches
-• One-click access to previous queries
-• Active tab integration updates the current trade tab instead of opening extra windows
-• Version-filtered history keeps PoE1 and PoE2 navigation clean
+• Automatically track visited trade searches
+• Return to previous queries with one click
+• Update the active trade tab instead of opening extra windows
+• Keep PoE1 and PoE2 history separate for cleaner navigation
 
 🎨 SMART RESULT ENHANCEMENTS
-• Live chaos/divine price equivalents via poe.ninja for PoE1 and PoE2
+• Show live chaos/divine price equivalents from poe.ninja for PoE1 and PoE2
 • Highlight active stat filters directly in search results
-• Socket breakpoint warnings for armor items
-• Pinned result navigation with auto-scroll back to selected items
-• Integrated Finer Filters actions for quick stat modifications
-• Optional Mageblood Legacy descriptions for PoE2, localized across supported languages
-• Craft of Exile advanced export for supported PoE1 and PoE2 items
-• Optional PoE2 copy helper for Path of Building workflows
+• Adjust quick filters, including a shortcut to clear Buyout Price
+• Show socket breakpoint warnings for armour items
+• Navigate pinned results and auto-scroll back to the selected item
+• Use integrated Finer Filters for fast stat modifications
+• Open matching PoE Wiki or PoE2 Wiki pages for unique items
+• Show optional Mageblood Legacy descriptions for PoE2 in every supported interface language
+• Copy supported PoE1/PoE2 items in Craft of Exile's advanced import format
+• Optionally include desecrated modifiers in Craft of Exile exports
+• Use the optional PoE2 copy helper for Path of Building workflows
 
-⚙️ SIDEBAR & POPUP CUSTOMIZATION
-• Resizable panel that adapts the trade site layout
-• Dock left or right - your choice
-• Minimize to a floating pill to reclaim screen space
-• Persistent width, position, and result-tool settings
-• Popup shortcuts for Wiki, PoE2 Wiki, Path of Regex, Craft of Exile, PoEDb, PoE2Db, and poe.ninja
-• Multi-region support across official PoE trade sites
+⚙️ SIDEBAR, POPUP & CUSTOMIZATION
+• Resizable sidebar that adapts the trade-site layout
+• Dock the panel on the left or right, or minimize it to a floating pill
+• Persist sidebar width, position, text size, language, and result-tool preferences
+• Choose Small, Medium, Large, or Extra interface text
+• Configure Quick Filter Presets in the sidebar or directly above the trade site's Stat Filters
+• Find setup help and the onboarding tutorial from About
+• Open grouped popup shortcuts for Wiki, PoE2 Wiki, Path of Regex, Craft of Exile, PoEDb, PoE2Db, and poe.ninja
 
-🌍 SUPPORTED REGIONS:
-• Global (pathofexile.com)
-• KakaoGames (poe2.kakaogames.com)
-• Localizations: BR, RU, TH, DE, FR, ES, JP
+🔄 BROWSER SYNC & STORAGE
+• Sync bookmarks, bookmark folders, and extension settings between installations signed into the same browser profile
+• Safely migrate existing bookmark and settings data when updating
+• Compact and chunk synced data to stay within browser Sync storage limits
+• Keep search history and other high-volume data local to the browser
 
-💿 DATA PRIVACY:
-✓ 100% local browser storage - no saved-search data sent to servers
-✓ No user tracking or analytics
-✓ Only reads from poe.ninja for pricing ratios
+🌍 SUPPORTED TRADE SITES & LANGUAGES
+• Global: pathofexile.com
+• Localized trade sites: BR, RU, TH, DE, FR, ES, and JP
+• Kakao Games: poe.kakaogames.com and poe2.kakaogames.com
+• Interface languages: English, Portuguese, Russian, Thai, German, French, Spanish, Japanese, and Korean
+
+💿 DATA PRIVACY
+✓ No PoeTradePlus account, tracking, analytics, or application-owned data server
+✓ Saved-search data stays in browser storage; when browser Sync is enabled, bookmarks and settings use the browser's built-in Sync service
+✓ Only reads poe.ninja for price ratios; external reference sites open only when you choose them
 ✓ Full source code available on GitHub

--- a/components/Layout.svelte
+++ b/components/Layout.svelte
@@ -8,6 +8,7 @@ import infoIcon from "lucide-static/icons/info.svg?raw";
   import Bookmarks from "./pages/Bookmarks.svelte";
   import BulkSellers from "./pages/BulkSellers.svelte";
   import History from "./pages/History.svelte";
+  import PinnedItems from "./pages/PinnedItems.svelte";
   import OnboardingModal from "./OnboardingModal.svelte";
 import Settings from "./pages/Settings.svelte";
 import About from "./pages/About.svelte";
@@ -33,7 +34,7 @@ import About from "./pages/About.svelte";
   const ONBOARDING_FOLDER_ID_KEY = "layout-onboarding-folder-id";
   const VERSION_NOTICE_SEEN_KEY = "layout-version-notice-seen";
 
-  let currentPage: 'bookmarks' | 'bulk' | 'history' | 'about' | 'settings' = $state('bookmarks');
+  let currentPage: 'bookmarks' | 'bulk' | 'pinned' | 'history' | 'about' | 'settings' = $state('bookmarks');
   let currentTradeVersion: "1" | "2" = $state(tradeLocationService.current.version);
   let isMinimized = $state(false);
   let isResizing = $state(false);
@@ -312,6 +313,9 @@ import About from "./pages/About.svelte";
       currentPage = 'bookmarks';
     }
   });
+  $effect(() => {
+    if (!$settings.showPinnedItems && currentPage === 'pinned') currentPage = 'bookmarks';
+  });
 
   const currentLocation = tradeLocationService.locationStore;
   let minimizedStorageKey = $derived(`${MINIMIZED_STORAGE_KEY}-${$currentLocation.version}`);
@@ -431,6 +435,11 @@ import About from "./pages/About.svelte";
       </button>
     {/if}
 
+    {#if $settings.showPinnedItems}
+      <button class="nav-item {currentPage === 'pinned' ? 'is-active' : ''}" onclick={() => currentPage = 'pinned'}>
+        <span class="nav-item__label">{translate($languageStore, "settings.pinnedTitle")}</span>
+      </button>
+    {/if}
     {#if $settings.showHistory}
       <button 
           class="nav-item {currentPage === 'history' ? 'is-active' : ''} {showOnboarding && onboardingHighlightedPage === 'history' ? 'is-onboarding-focus' : ''}" 
@@ -480,6 +489,8 @@ import About from "./pages/About.svelte";
           tutorialFolderId={showOnboarding ? onboardingTutorialFolderId : null} />
     {:else if currentPage === 'bulk' && $settings.showBulkSellers}
         <BulkSellers />
+    {:else if currentPage === 'pinned' && $settings.showPinnedItems}
+        <PinnedItems />
     {:else if currentPage === 'history' && $settings.showHistory}
         <History />
     {:else if currentPage === 'settings'}

--- a/components/pages/PinnedItems.svelte
+++ b/components/pages/PinnedItems.svelte
@@ -18,7 +18,10 @@
   {#if $pinnedItems.length > 0}
     <div class="items-grid">
       {#each $pinnedItems as item (item.id)}
-        <div class="pinned-item-card">
+        <article class="pinned-item-card">
+          <header class="pinned-item-card__header">
+            <h3 title={item.title}>{item.title}</h3>
+          </header>
           <div class="item-content">
             {@html item.detailsHtml}
             <div class="rendered-wrapper">
@@ -32,23 +35,24 @@
             <Button label="Scroll to" theme="blue" onClick={() => scrollTo(item.id)} />
             <Button label="Unpin" theme="blue" onClick={() => unpin(item.id)} />
           </div>
-        </div>
+        </article>
       {/each}
     </div>
     
     <Button label="Clear All" theme="gold" icon="✕" onClick={clear} />
+    <AlertMessage type="warning" message="Note: Pinned items are only kept for the current session." />
   {:else}
     <AlertMessage type="warning" message="No pinned items yet. Use the 'Pin' button on trade results." />
   {/if}
-
-  <AlertMessage type="warning" message="Note: Pinned items are only kept for the current session." />
 </div>
 
 <style>
 .pinned-items-page {
   display: flex;
   flex-direction: column;
-  gap: 10px;
+  gap: 12px;
+  min-height: 100%;
+  font-family: "FontinSmallcaps", serif;
   width: 100%;
   min-width: 0;
   max-width: 100%;
@@ -57,22 +61,49 @@
 .items-grid {
   display: flex;
   flex-direction: column;
-  gap: 15px;
-  margin-bottom: 10px;
+  gap: 10px;
+  margin-bottom: 2px;
   width: 100%;
   min-width: 0;
 }
 
 .pinned-item-card {
-  background-color: #000;
-  border: 1px solid #1a2a3a;
+  border: 1px solid rgba(238, 238, 238, 0.07);
+  border-radius: 8px;
+  background: linear-gradient(180deg, rgba(238, 238, 238, 0.03), rgba(238, 238, 238, 0.012)), rgba(5, 5, 5, 0.46);
   width: 100%;
   min-width: 0;
   overflow: hidden;
+  box-shadow: inset 0 1px 0 rgba(238, 238, 238, 0.025), 0 8px 18px rgba(0, 0, 0, 0.12);
+}
+.pinned-item-card:hover {
+  border-color: rgba(163, 141, 109, 0.22);
+}
+.pinned-item-card__header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 10px 12px 9px;
+  border-bottom: 1px solid rgba(238, 238, 238, 0.07);
+  background: linear-gradient(180deg, rgba(26, 42, 58, 0.58), rgba(15, 28, 46, 0.38));
+}
+.pinned-item-card__header h3 {
+  flex: 1;
+  min-width: 0;
+  margin: 0;
+  color: rgba(238, 238, 238, 0.95);
+  font-size: calc(13px * var(--bt-text-scale, 1));
+  font-weight: 700;
+  line-height: 1.25;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 .pinned-item-card :global(.itemPopupContainer) {
   margin: 0;
-  background-color: #000;
+  max-width: 100%;
+  background: transparent;
 }
 .pinned-item-card :global(.itemPopupAdditional) {
   padding: 5px;
@@ -83,14 +114,16 @@
 .rendered-wrapper {
   display: flex;
   justify-content: center;
-  background-color: #000;
+  padding: 8px 10px;
+  background: rgba(5, 5, 5, 0.28);
 }
 
 .pricing-wrapper {
-  padding: 10px;
+  padding: 8px 12px;
   text-align: center;
-  background-color: #000;
-  color: #a38d6d;
+  background: rgba(163, 141, 109, 0.045);
+  border-top: 1px solid rgba(163, 141, 109, 0.08);
+  color: rgba(196, 177, 140, 0.9);
 }
 .pricing-wrapper :global(img) {
   height: 24px;
@@ -98,15 +131,28 @@
 }
 
 .item-actions {
-  display: flex;
-  gap: 5px;
-  padding: 10px;
-  background-color: #000;
-  border-top: 1px solid rgba(26, 42, 58, 0.3);
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 6px;
+  padding: 9px 10px;
+  background: rgba(5, 5, 5, 0.34);
+  border-top: 1px solid rgba(238, 238, 238, 0.07);
   width: 100%;
   min-width: 0;
 }
 .item-actions :global(button) {
-  flex: 1;
+  width: 100%;
+}
+
+.pinned-items-page :global(.alert-message.is-warning) {
+  margin: 0;
+  border: 1px solid rgba(163, 141, 109, 0.2);
+  border-radius: 8px;
+  background: linear-gradient(180deg, rgba(163, 141, 109, 0.075), rgba(163, 141, 109, 0.035)), rgba(5, 5, 5, 0.48);
+  color: rgba(238, 238, 238, 0.78);
+  box-shadow: inset 0 1px 0 rgba(238, 238, 238, 0.02);
+}
+.pinned-items-page :global(.alert-message.is-warning .icon) {
+  color: rgba(196, 177, 140, 0.72);
 }
 </style>

--- a/components/pages/PinnedItems.svelte
+++ b/components/pages/PinnedItems.svelte
@@ -1,18 +1,13 @@
 <script lang="ts">
-  import { itemResultsService } from "../../lib/services/item-results";
-  import { onMount } from "svelte";
+  import { pinnedItemsService } from "../../lib/services/pinned-items";
   import { sendMessageToActiveTradeTab } from "../../lib/services/active-trade-tab";
   import Button from "../Button.svelte";
   import AlertMessage from "../AlertMessage.svelte";
 
-  const pinnedItems = itemResultsService;
+  const pinnedItems = pinnedItemsService;
 
-  onMount(() => {
-    void itemResultsService.initialize();
-  });
-
-  const unpin = (id: string) => itemResultsService.unpin(id);
-  const clear = () => itemResultsService.clear();
+  const unpin = (id: string) => pinnedItemsService.unpin(id);
+  const clear = () => pinnedItemsService.clear();
 
   const scrollTo = async (id: string) => {
     await sendMessageToActiveTradeTab({ query: "scroll-to-item", itemId: id });

--- a/components/pages/PinnedItems.svelte
+++ b/components/pages/PinnedItems.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { pinnedItemsService } from "../../lib/services/pinned-items";
+  import { languageStore, translate } from "../../lib/services/i18n";
   import pinOffIcon from "lucide-static/icons/pin-off.svg?raw";
   import Button from "../Button.svelte";
   import AlertMessage from "../AlertMessage.svelte";
@@ -38,17 +39,17 @@
             </div>
           </div>
           <div class="item-actions">
-            <Button label="Scroll to" theme="blue" onClick={() => scrollTo(item.id)} />
-            <Button label="Unpin" iconHtml={pinOffIcon} theme="blue" onClick={() => unpin(item.id)} />
+            <Button label={translate($languageStore, "pinned.scrollTo")} theme="blue" onClick={() => scrollTo(item.id)} />
+            <Button label={translate($languageStore, "pinned.unpin")} iconHtml={pinOffIcon} theme="blue" onClick={() => unpin(item.id)} />
           </div>
         </article>
       {/each}
     </div>
     
-    <Button label="Clear All" theme="gold" icon="✕" onClick={clear} />
-    <AlertMessage type="warning" message="Note: Pinned items are only kept for the current session." />
+    <Button label={translate($languageStore, "pinned.clear")} theme="gold" icon="✕" onClick={clear} />
+    <AlertMessage type="warning" message={translate($languageStore, "pinned.sessionNote")} />
   {:else}
-    <AlertMessage type="warning" message="No pinned items yet. Use the 'Pin' button on trade results." />
+    <AlertMessage type="warning" message={translate($languageStore, "pinned.empty")} />
   {/if}
 </div>
 

--- a/components/pages/PinnedItems.svelte
+++ b/components/pages/PinnedItems.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { pinnedItemsService } from "../../lib/services/pinned-items";
-  import { sendMessageToActiveTradeTab } from "../../lib/services/active-trade-tab";
+  import pinOffIcon from "lucide-static/icons/pin-off.svg?raw";
   import Button from "../Button.svelte";
   import AlertMessage from "../AlertMessage.svelte";
 
@@ -9,8 +9,14 @@
   const unpin = (id: string) => pinnedItemsService.unpin(id);
   const clear = () => pinnedItemsService.clear();
 
-  const scrollTo = async (id: string) => {
-    await sendMessageToActiveTradeTab({ query: "scroll-to-item", itemId: id });
+  const scrollTo = (id: string) => {
+    const row = Array.from(document.querySelectorAll<HTMLElement>("[data-bt-pin-id]"))
+      .find((element) => element.dataset.btPinId === id);
+    if (!row) return;
+
+    row.scrollIntoView({ block: "center", behavior: "smooth" });
+    row.classList.add("bt-pinned-glow");
+    window.setTimeout(() => row.classList.remove("bt-pinned-glow"), 2000);
   };
 </script>
 
@@ -33,7 +39,7 @@
           </div>
           <div class="item-actions">
             <Button label="Scroll to" theme="blue" onClick={() => scrollTo(item.id)} />
-            <Button label="Unpin" theme="blue" onClick={() => unpin(item.id)} />
+            <Button label="Unpin" iconHtml={pinOffIcon} theme="blue" onClick={() => unpin(item.id)} />
           </div>
         </article>
       {/each}

--- a/components/pages/Settings.svelte
+++ b/components/pages/Settings.svelte
@@ -196,6 +196,11 @@
       flashMessages.alert(translate($languageStore, "settings.saveFailed"));
     }
   }
+  async function handlePinnedItemsChange(showPinnedItems: boolean) {
+    if (!(await settings.updatePinnedItemsVisibility(showPinnedItems))) {
+      flashMessages.alert(translate($languageStore, "settings.saveFailed"));
+    }
+  }
 
   async function handleHistoryChange(showHistory: boolean) {
     if (!(await settings.updateHistoryVisibility(showHistory))) {
@@ -591,6 +596,14 @@
               stateLabel={toggleSwitchLabel($settings.showBulkSellers)}
               onToggle={() => handleBulkSellersChange(!$settings.showBulkSellers)}
             />
+          </div>
+
+          <div class="settings-row">
+            <div class="settings-row__copy">
+              <div class="settings-row__title">{translate($languageStore, "settings.pinnedTitle")}</div>
+              <div class="settings-row__description">{translate($languageStore, "settings.pinnedDescription")}</div>
+            </div>
+            <ToggleRow checked={$settings.showPinnedItems} label={translate($languageStore, "settings.pinnedTitle")} stateLabel={toggleSwitchLabel($settings.showPinnedItems)} onToggle={() => handlePinnedItemsChange(!$settings.showPinnedItems)} />
           </div>
 
           <div class="settings-row" data-tutorial="settings-history">

--- a/contents/index.svelte
+++ b/contents/index.svelte
@@ -53,7 +53,10 @@
         return
       }
 
-      const el = document.querySelector<HTMLElement>(`.row[data-id="${escapeCssAttributeValue(request.itemId)}"]`)
+      const itemId = escapeCssAttributeValue(request.itemId)
+      const el = document.querySelector<HTMLElement>(
+        `[data-bt-pin-id="${itemId}"], .result-item[data-id="${itemId}"], .row[data-id="${itemId}"]`
+      )
       if (!el) {
         return
       }

--- a/lib/data/whats-new.ts
+++ b/lib/data/whats-new.ts
@@ -102,6 +102,13 @@ const version1117Features: WhatsNewItem[] = [
   }
 ];
 
+const version1118Features: WhatsNewItem[] = [
+  {
+    titleKey: "whatsNew.item.pinnedItemsTitle",
+    descriptionKey: "whatsNew.item.pinnedItemsDescription"
+  }
+];
+
 const version112Features: WhatsNewItem[] = [
   {
     title: "External reference links in the popup",
@@ -354,9 +361,18 @@ const version1110Features: WhatsNewItem[] = [
 ];
 
 export const latestWhatsNew: WhatsNewEntry = {
-  version: "1.1.17",
-  date: "2026-07-24",
+  version: "1.1.18",
+  date: "2026-07-26",
   sections: [
+    {
+      title: "1.1.18",
+      groups: [
+        {
+          titleKey: "whatsNew.section.features",
+          items: version1118Features
+        }
+      ]
+    },
     {
       title: "1.1.17",
       groups: [

--- a/lib/services/i18n/de.ts
+++ b/lib/services/i18n/de.ts
@@ -261,6 +261,13 @@ export const germanTranslations: Record<string, TranslationValue> = {
   "whatsNew.item.activeRealmBookmarksTitle": "Lesezeichen folgen dem aktiven Trade-Realm",
   "whatsNew.item.activeRealmBookmarksDescription":
     "Gespeicherte Suchen öffnen sich jetzt in Liga und Realm des aktiven Trade-Tabs; die gespeicherte Liga bleibt als Fallback erhalten.",
+  "pinned.scrollTo": "Zum Ergebnis",
+  "pinned.unpin": "Lösen",
+  "pinned.clear": "Alle löschen",
+  "pinned.empty": "Noch keine angehefteten Gegenstände. Nutze die Anheften-Schaltfläche in den Trade-Ergebnissen.",
+  "pinned.sessionNote": "Angeheftete Gegenstände werden bei einer neuen Suche oder beim Neuladen der Seite entfernt.",
+  "whatsNew.item.pinnedItemsTitle": "Angeheftete Gegenstände sind zurück",
+  "whatsNew.item.pinnedItemsDescription": "Nach dem ursprünglichen Better-Trading-Ablauf neu umgesetzt: Optionale Pins halten ein Ergebnis während der aktuellen Suche verfügbar und springen über die Seitenleiste dorthin zurück.",
   "whatsNew.item.buyoutClearTitle": "Schnellaktion zum Leeren des Kaufpreises",
   "whatsNew.item.buyoutClearDescription":
     "Schnellfilter-Voreinstellungen enthalten jetzt eine Schaltfläche zum Leeren, die den Kaufpreis auf Wert in Chaossphären setzt und mit unterstützten Trade-Website-Sprachen funktioniert.",

--- a/lib/services/i18n/de.ts
+++ b/lib/services/i18n/de.ts
@@ -279,6 +279,8 @@ export const germanTranslations: Record<string, TranslationValue> = {
   "settings.equivalentRefreshUnavailable":
     "Öffne zuerst eine Handelsliga, um den poe.ninja-Kurs zu aktualisieren.",
   "settings.bulkTitle": "Bulk-Verkäufer",
+  "settings.pinnedTitle": "Angeheftete Gegenstände",
+  "settings.pinnedDescription": "Behält ausgewählte Ergebnisse in diesem Tab, bis er geschlossen wird.",
   "settings.bulkDescription":
     "Zeige oder verberge den Bulk-Tab, der wiederholte Verkäufer aus den aktuellen Suchergebnissen gruppiert.",
   "settings.historyTitle": "Verlauf",

--- a/lib/services/i18n/en.ts
+++ b/lib/services/i18n/en.ts
@@ -473,6 +473,13 @@ export const englishTranslations: Record<string, TranslationValue> = {
   "whatsNew.item.activeRealmBookmarksTitle": "Bookmarks follow active trade realm",
   "whatsNew.item.activeRealmBookmarksDescription":
     "Saved searches now open in the active trade tab's current league and realm, while keeping their saved league as a fallback.",
+  "pinned.scrollTo": "Scroll to",
+  "pinned.unpin": "Unpin",
+  "pinned.clear": "Clear all",
+  "pinned.empty": "No pinned items yet. Use the Pin button on trade results.",
+  "pinned.sessionNote": "Pinned items are cleared when you start a new search or reload the page.",
+  "whatsNew.item.pinnedItemsTitle": "Pinned items return",
+  "whatsNew.item.pinnedItemsDescription": "Reimplemented from the original Better Trading workflow, optional pins keep a result available during the current search and let you jump back to it from the sidebar.",
   "whatsNew.item.buyoutClearTitle": "Clear Buyout Price shortcut",
   "whatsNew.item.buyoutClearDescription":
     "Quick Filter Presets now include a Clear button that resets Buyout Price to Chaos Orb Equivalent and works with supported trade-site languages."

--- a/lib/services/i18n/en.ts
+++ b/lib/services/i18n/en.ts
@@ -255,6 +255,8 @@ export const englishTranslations: Record<string, TranslationValue> = {
   "settings.quickFiltersPlacementPage": "Trade Page",
   "settings.quickFiltersPlacementSidebar": "Sidebar",
   "settings.bulkTitle": "Bulk Sellers",
+  "settings.pinnedTitle": "Pinned items",
+  "settings.pinnedDescription": "Keep selected trade results available in this browser tab until it closes.",
   "settings.bulkDescription":
     "Show or hide the bulk sellers tab that groups repeated sellers from the current trade results.",
   "settings.historyTitle": "History",

--- a/lib/services/i18n/es.ts
+++ b/lib/services/i18n/es.ts
@@ -260,6 +260,8 @@ export const spanishTranslations: Record<string, TranslationValue> = {
   "settings.quickFiltersPlacementPage": "Página de trade",
   "settings.quickFiltersPlacementSidebar": "Sidebar",
   "settings.bulkTitle": "Bulk Sellers",
+  "settings.pinnedTitle": "Objetos fijados",
+  "settings.pinnedDescription": "Mantiene los resultados seleccionados disponibles en esta pestaña hasta que se cierre.",
   "settings.bulkDescription":
     "Mostrá u ocultá la pestaña Bulk que agrupa vendedores repetidos de los resultados actuales.",
   "settings.historyTitle": "Historial",

--- a/lib/services/i18n/es.ts
+++ b/lib/services/i18n/es.ts
@@ -482,6 +482,13 @@ export const spanishTranslations: Record<string, TranslationValue> = {
   "whatsNew.item.activeRealmBookmarksTitle": "Los marcadores siguen el reino de trade activo",
   "whatsNew.item.activeRealmBookmarksDescription":
     "Las búsquedas guardadas ahora se abren en la liga y el reino actuales de la pestaña Trade activa, manteniendo la liga guardada como alternativa.",
+  "pinned.scrollTo": "Ir al resultado",
+  "pinned.unpin": "Quitar fijación",
+  "pinned.clear": "Limpiar todos",
+  "pinned.empty": "Todavía no hay objetos fijados. Usá el botón Fijar en los resultados de Trade.",
+  "pinned.sessionNote": "Los objetos fijados se eliminan al iniciar una búsqueda nueva o recargar la página.",
+  "whatsNew.item.pinnedItemsTitle": "Vuelven los objetos fijados",
+  "whatsNew.item.pinnedItemsDescription": "Reimplementados a partir del flujo original de Better Trading, los pins opcionales mantienen un resultado disponible durante la búsqueda actual y permiten volver a él desde la barra lateral.",
   "whatsNew.item.buyoutClearTitle": "Acceso rápido para limpiar el precio de compra",
   "whatsNew.item.buyoutClearDescription":
     "Los ajustes preestablecidos de filtro rápido ahora incluyen un botón Limpiar que restablece Precio de compra a Equivalente a Orbe de caos y funciona en los idiomas compatibles del sitio de trade."

--- a/lib/services/i18n/fr.ts
+++ b/lib/services/i18n/fr.ts
@@ -266,6 +266,13 @@ export const frenchTranslations: Record<string, TranslationValue> = {
   "whatsNew.item.activeRealmBookmarksTitle": "Les favoris suivent le royaume trade actif",
   "whatsNew.item.activeRealmBookmarksDescription":
     "Les recherches enregistrées s’ouvrent maintenant dans la ligue et le royaume de l’onglet Trade actif, tout en conservant la ligue enregistrée comme solution de repli.",
+  "pinned.scrollTo": "Aller au résultat",
+  "pinned.unpin": "Désépingler",
+  "pinned.clear": "Tout effacer",
+  "pinned.empty": "Aucun objet épinglé pour le moment. Utilisez le bouton Épingler dans les résultats de Trade.",
+  "pinned.sessionNote": "Les objets épinglés sont supprimés lors d'une nouvelle recherche ou du rechargement de la page.",
+  "whatsNew.item.pinnedItemsTitle": "Les objets épinglés reviennent",
+  "whatsNew.item.pinnedItemsDescription": "Réimplémentés depuis le flux original de Better Trading, les épingles facultatives gardent un résultat disponible pendant la recherche et permettent d'y revenir depuis la barre latérale.",
   "whatsNew.item.buyoutClearTitle": "Raccourci pour effacer le prix de rachat",
   "whatsNew.item.buyoutClearDescription":
     "Les préréglages de filtre rapide incluent désormais un bouton Effacer qui règle le prix de rachat sur Équivalent en orbes du chaos et fonctionne avec les langues prises en charge du site trade.",

--- a/lib/services/i18n/fr.ts
+++ b/lib/services/i18n/fr.ts
@@ -284,6 +284,8 @@ export const frenchTranslations: Record<string, TranslationValue> = {
   "settings.equivalentRefreshUnavailable":
     "Ouvrez d’abord une ligue de trade pour actualiser le taux poe.ninja.",
   "settings.bulkTitle": "Vendeurs bulk",
+  "settings.pinnedTitle": "Objets épinglés",
+  "settings.pinnedDescription": "Conserve les résultats sélectionnés dans cet onglet jusqu'à sa fermeture.",
   "settings.bulkDescription":
     "Afficher ou masquer l’onglet Bulk qui regroupe les vendeurs répétés des résultats actuels.",
   "settings.historyTitle": "Historique",

--- a/lib/services/i18n/ja.ts
+++ b/lib/services/i18n/ja.ts
@@ -269,6 +269,13 @@ export const japaneseTranslations: Record<string, TranslationValue> = {
   "whatsNew.item.activeRealmBookmarksTitle": "ブックマークがアクティブなTradeリーグとRealmに追従",
   "whatsNew.item.activeRealmBookmarksDescription":
     "保存した検索はアクティブなTradeタブの現在のリーグとRealmで開き、保存済みリーグはフォールバックとして保持されます。",
+  "pinned.scrollTo": "結果へ移動",
+  "pinned.unpin": "固定を解除",
+  "pinned.clear": "すべてクリア",
+  "pinned.empty": "固定したアイテムはまだありません。Trade の結果にある固定ボタンを使ってください。",
+  "pinned.sessionNote": "新しい検索を開始するかページを再読み込みすると、固定したアイテムは削除されます。",
+  "whatsNew.item.pinnedItemsTitle": "固定したアイテムが復活",
+  "whatsNew.item.pinnedItemsDescription": "Better Trading の元のフローをもとに再実装しました。任意の固定で現在の検索中に結果を残し、サイドバーからその結果へ戻れます。",
   "whatsNew.item.buyoutClearTitle": "バイアウト価格をクリアするショートカット",
   "whatsNew.item.buyoutClearDescription":
     "クイックフィルタープリセットに、バイアウト価格をカオスオーブ同等物へ戻すクリアボタンが追加され、対応するTradeサイトの言語で動作します。",

--- a/lib/services/i18n/ja.ts
+++ b/lib/services/i18n/ja.ts
@@ -287,6 +287,8 @@ export const japaneseTranslations: Record<string, TranslationValue> = {
   "settings.equivalentRefreshUnavailable":
     "まずトレードリーグを開いてから poe.ninja のレートを更新してください。",
   "settings.bulkTitle": "Bulk 売り手",
+  "settings.pinnedTitle": "固定したアイテム",
+  "settings.pinnedDescription": "選択した結果を、このタブを閉じるまで保持します。",
   "settings.bulkDescription":
     "現在の結果で同じ売り手が複数回出る場合にまとめる Bulk タブの表示/非表示を切り替えます。",
   "settings.historyTitle": "履歴",

--- a/lib/services/i18n/ko.ts
+++ b/lib/services/i18n/ko.ts
@@ -266,6 +266,13 @@ export const koreanTranslations: Record<string, TranslationValue> = {
   "whatsNew.item.activeRealmBookmarksTitle": "북마크가 활성 Trade 리그와 Realm을 따름",
   "whatsNew.item.activeRealmBookmarksDescription":
     "저장된 검색은 이제 활성 Trade 탭의 현재 리그와 Realm에서 열리며, 저장된 리그는 대체 값으로 유지됩니다.",
+  "pinned.scrollTo": "결과로 이동",
+  "pinned.unpin": "고정 해제",
+  "pinned.clear": "모두 지우기",
+  "pinned.empty": "아직 고정한 아이템이 없습니다. Trade 결과에서 고정 버튼을 사용하세요.",
+  "pinned.sessionNote": "새 검색을 시작하거나 페이지를 새로 고치면 고정한 아이템이 제거됩니다.",
+  "whatsNew.item.pinnedItemsTitle": "고정한 아이템이 돌아왔습니다",
+  "whatsNew.item.pinnedItemsDescription": "원본 Better Trading 흐름을 바탕으로 다시 구현했습니다. 선택적인 고정으로 현재 검색 중 결과를 유지하고 사이드바에서 해당 결과로 돌아갈 수 있습니다.",
   "whatsNew.item.buyoutClearTitle": "즉시 구매 가격 지우기 단축키",
   "whatsNew.item.buyoutClearDescription":
     "빠른 필터 프리셋에 즉시 구매 가격을 카오스 오브 등가물로 설정하는 지우기 버튼이 추가되었으며, 지원되는 Trade 사이트 언어에서 작동합니다.",

--- a/lib/services/i18n/ko.ts
+++ b/lib/services/i18n/ko.ts
@@ -283,6 +283,8 @@ export const koreanTranslations: Record<string, TranslationValue> = {
   "settings.equivalentRefreshUnavailable":
     "먼저 거래 리그를 연 다음 poe.ninja 환율을 새로고침하세요.",
   "settings.bulkTitle": "Bulk 판매자",
+  "settings.pinnedTitle": "고정한 아이템",
+  "settings.pinnedDescription": "선택한 결과를 이 탭을 닫을 때까지 유지합니다.",
   "settings.bulkDescription":
     "현재 결과에서 같은 판매자가 여러 번 나올 때 묶어 보여주는 Bulk 탭을 표시하거나 숨깁니다.",
   "settings.historyTitle": "기록",

--- a/lib/services/i18n/pt.ts
+++ b/lib/services/i18n/pt.ts
@@ -272,6 +272,13 @@ export const portugueseTranslations: Record<string, TranslationValue> = {
   "whatsNew.item.activeRealmBookmarksTitle": "Favoritos seguem o reino de trade ativo",
   "whatsNew.item.activeRealmBookmarksDescription":
     "Pesquisas salvas agora abrem na liga e no reino atuais da aba Trade ativa, mantendo a liga salva como alternativa.",
+  "pinned.scrollTo": "Ir ao resultado",
+  "pinned.unpin": "Desafixar",
+  "pinned.clear": "Limpar tudo",
+  "pinned.empty": "Ainda não há itens fixados. Use o botão Fixar nos resultados de Trade.",
+  "pinned.sessionNote": "Os itens fixados são removidos ao iniciar uma nova busca ou recarregar a página.",
+  "whatsNew.item.pinnedItemsTitle": "Itens fixados retornam",
+  "whatsNew.item.pinnedItemsDescription": "Reimplementados a partir do fluxo original do Better Trading, os pins opcionais mantêm um resultado disponível durante a busca atual e permitem voltar a ele pela barra lateral.",
   "whatsNew.item.buyoutClearTitle": "Atalho para limpar o preço de compra",
   "whatsNew.item.buyoutClearDescription":
     "Os presets de filtro rápido agora incluem um botão Limpar que redefine Preço de Compra para Equivalente a Orbe do Caos e funciona nos idiomas compatíveis do site de trade.",

--- a/lib/services/i18n/pt.ts
+++ b/lib/services/i18n/pt.ts
@@ -290,6 +290,8 @@ export const portugueseTranslations: Record<string, TranslationValue> = {
   "settings.equivalentRefreshUnavailable":
     "Abra uma liga de trade primeiro para atualizar a taxa do poe.ninja.",
   "settings.bulkTitle": "Vendedores bulk",
+  "settings.pinnedTitle": "Itens fixados",
+  "settings.pinnedDescription": "Mantém os resultados selecionados nesta aba até ela ser fechada.",
   "settings.bulkDescription":
     "Mostre ou oculte a aba de vendedores bulk que agrupa vendedores repetidos dos resultados atuais.",
   "settings.historyTitle": "Histórico",

--- a/lib/services/i18n/ru.ts
+++ b/lib/services/i18n/ru.ts
@@ -259,6 +259,13 @@ export const russianTranslations: Record<string, TranslationValue> = {
   "whatsNew.item.activeRealmBookmarksTitle": "Закладки следуют активному миру trade",
   "whatsNew.item.activeRealmBookmarksDescription":
     "Сохранённые поиски теперь открываются в текущей лиге и мире активной вкладки Trade, сохраняя сохранённую лигу как резервный вариант.",
+  "pinned.scrollTo": "Перейти к результату",
+  "pinned.unpin": "Открепить",
+  "pinned.clear": "Очистить все",
+  "pinned.empty": "Закрепленных предметов пока нет. Используйте кнопку закрепления в результатах Trade.",
+  "pinned.sessionNote": "Закрепленные предметы удаляются при новом поиске или перезагрузке страницы.",
+  "whatsNew.item.pinnedItemsTitle": "Закрепленные предметы вернулись",
+  "whatsNew.item.pinnedItemsDescription": "Повторно реализованные по исходному потоку Better Trading, необязательные закрепления сохраняют результат во время текущего поиска и позволяют вернуться к нему из боковой панели.",
   "whatsNew.item.buyoutClearTitle": "Быстрая очистка цены выкупа",
   "whatsNew.item.buyoutClearDescription":
     "В быстрых фильтрах теперь есть кнопка «Очистить», которая переключает цену выкупа на эквивалент сферы хаоса и работает с поддерживаемыми языками сайта trade.",

--- a/lib/services/i18n/ru.ts
+++ b/lib/services/i18n/ru.ts
@@ -277,6 +277,8 @@ export const russianTranslations: Record<string, TranslationValue> = {
   "settings.equivalentRefreshUnavailable":
     "Сначала откройте торговую лигу, чтобы обновить курс poe.ninja.",
   "settings.bulkTitle": "Bulk-продавцы",
+  "settings.pinnedTitle": "Закрепленные предметы",
+  "settings.pinnedDescription": "Сохраняет выбранные результаты в этой вкладке до ее закрытия.",
   "settings.bulkDescription":
     "Показывать или скрывать вкладку Bulk, которая группирует повторяющихся продавцов из текущих результатов.",
   "settings.historyTitle": "История",

--- a/lib/services/i18n/th.ts
+++ b/lib/services/i18n/th.ts
@@ -274,6 +274,8 @@ export const thaiTranslations: Record<string, TranslationValue> = {
   "settings.equivalentRefreshUnavailable":
     "เปิดลีกเทรดก่อน เพื่อรีเฟรชเรต poe.ninja",
   "settings.bulkTitle": "ผู้ขาย Bulk",
+  "settings.pinnedTitle": "ไอเท็มที่ปักหมุด",
+  "settings.pinnedDescription": "เก็บผลลัพธ์ที่เลือกไว้ในแท็บนี้จนกว่าจะปิดแท็บ",
   "settings.bulkDescription":
     "แสดงหรือซ่อนแท็บ Bulk ที่รวมผู้ขายที่ซ้ำกันจากผลลัพธ์ปัจจุบัน",
   "settings.historyTitle": "ประวัติ",

--- a/lib/services/i18n/th.ts
+++ b/lib/services/i18n/th.ts
@@ -258,6 +258,13 @@ export const thaiTranslations: Record<string, TranslationValue> = {
   "whatsNew.item.activeRealmBookmarksTitle": "บุ๊กมาร์กใช้ realm ของ trade ที่กำลังใช้งาน",
   "whatsNew.item.activeRealmBookmarksDescription":
     "การค้นหาที่บันทึกไว้จะเปิดด้วยลีกและ realm ปัจจุบันของแท็บ Trade ที่ใช้งานอยู่ โดยเก็บลีกที่บันทึกไว้เป็นทางเลือกสำรอง.",
+  "pinned.scrollTo": "ไปยังผลลัพธ์",
+  "pinned.unpin": "เลิกปักหมุด",
+  "pinned.clear": "ล้างทั้งหมด",
+  "pinned.empty": "ยังไม่มีไอเท็มที่ปักหมุด ใช้ปุ่มปักหมุดในผลลัพธ์ Trade",
+  "pinned.sessionNote": "ไอเท็มที่ปักหมุดจะถูกลบเมื่อเริ่มการค้นหาใหม่หรือรีโหลดหน้า",
+  "whatsNew.item.pinnedItemsTitle": "ไอเท็มที่ปักหมุดกลับมาแล้ว",
+  "whatsNew.item.pinnedItemsDescription": "นำกลับมาใช้ใหม่จากขั้นตอนดั้งเดิมของ Better Trading โดยหมุดที่เลือกใช้ได้จะเก็บผลลัพธ์ไว้ระหว่างการค้นหาปัจจุบันและกลับไปยังผลลัพธ์นั้นจากแถบด้านข้างได้",
   "whatsNew.item.buyoutClearTitle": "ปุ่มล้างราคาซื้อทันที",
   "whatsNew.item.buyoutClearDescription":
     "พรีเซ็ตตัวกรองด่วนมีปุ่มล้างที่ตั้งราคาซื้อทันทีเป็นเทียบเป็น Chaos Orb และใช้ได้กับภาษาของเว็บไซต์ trade ที่รองรับ.",

--- a/lib/services/item-results.ts
+++ b/lib/services/item-results.ts
@@ -20,6 +20,8 @@ import {
 import { flashMessages } from "./flash";
 import { experimentalSettings } from "./experimental";
 import { pinnedItemsService } from "./pinned-items";
+import pinIcon from "lucide-static/icons/pin.svg?raw";
+import pinOffIcon from "lucide-static/icons/pin-off.svg?raw";
 
 
 
@@ -378,6 +380,8 @@ export class ItemResultsService {
   }
 
   private async handleLocationChange() {
+    pinnedItemsService.clear();
+
     try {
       await this.fetchRatios();
     } catch (e) {
@@ -730,24 +734,35 @@ export class ItemResultsService {
       button.className = "bt-pin-button";
       button.addEventListener("click", (event) => {
         event.preventDefault();
-        event.stopPropagation();
+        event.stopImmediatePropagation();
+        const currentId = row.dataset.id;
+        console.debug("[Poe Trade Plus] Pin clicked", {
+          currentId,
+          rowConnected: row.isConnected
+        });
+        if (!currentId) {
+          console.debug("[Poe Trade Plus] Pin ignored: result has no id");
+          return;
+        }
         const title = row.querySelector<HTMLElement>(".itemName .itemHeader, .item-popup__header-line")?.textContent?.trim() || "Item";
         pinnedItemsService.toggle({
-          id,
+          id: currentId,
           title,
           detailsHtml: row.querySelector<HTMLElement>(".itemPopupContainer, .item-popup")?.outerHTML || "",
           renderedHtml: row.querySelector<HTMLElement>(".item")?.outerHTML || "",
           pricingHtml: row.querySelector<HTMLElement>("[data-field=price], .price")?.outerHTML || ""
         });
+        console.debug("[Poe Trade Plus] Pin toggled", { currentId });
         this.syncPinButton(row);
-      });
+      }, true);
       left.appendChild(button);
     }
     const pinned = pinnedItemsService.has(id);
     row.classList.toggle("bt-pinned", pinned);
-    button.textContent = pinned ? "Unpin" : "Pin";
-    button.title = button.textContent;
-    button.setAttribute("aria-label", button.textContent);
+    const label = pinned ? "Unpin" : "Pin";
+    button.innerHTML = pinned ? pinOffIcon : pinIcon;
+    button.title = label;
+    button.setAttribute("aria-label", label);
     row.dataset.btPinId = id;
   }
 

--- a/lib/services/item-results.ts
+++ b/lib/services/item-results.ts
@@ -201,6 +201,7 @@ export class ItemResultsService {
   };
   private showEquivalentPricing = false;
   private showMagebloodLegacyDescriptions = false;
+  private showPinnedItems = false;
   private unsubscribeSettings: (() => void) | null = null;
   private unsubscribeLocation: (() => void) | null = null;
   private readonly postSearchRefreshDelays = [80, 220, 500, 900];
@@ -277,18 +278,24 @@ export class ItemResultsService {
     await settings.load();
     this.showEquivalentPricing = settings.getCurrent().showEquivalentPricing;
     this.showMagebloodLegacyDescriptions = settings.getCurrent().showMagebloodLegacyDescriptions;
+    this.showPinnedItems = settings.getCurrent().showPinnedItems;
     this.unsubscribeSettings?.();
     this.unsubscribeSettings = settings.subscribe((value) => {
       const changed = this.showEquivalentPricing !== value.showEquivalentPricing;
       const magebloodChanged =
         this.showMagebloodLegacyDescriptions !== value.showMagebloodLegacyDescriptions;
+      const pinsChanged = this.showPinnedItems !== value.showPinnedItems;
       this.showEquivalentPricing = value.showEquivalentPricing;
       this.showMagebloodLegacyDescriptions = value.showMagebloodLegacyDescriptions;
+      this.showPinnedItems = value.showPinnedItems;
       if (changed) {
         this.refreshEquivalentPricing();
       }
       if (magebloodChanged) {
         this.refreshMagebloodLegacyDescriptions();
+      }
+      if (pinsChanged) {
+        this.refreshPinButtons();
       }
     });
     this.unsubscribeLocation?.();
@@ -724,10 +731,18 @@ export class ItemResultsService {
   }
 
   private syncPinButton(row: HTMLElement) {
+    const existingButton = row.querySelector<HTMLButtonElement>("button.bt-pin-button");
+    if (!this.showPinnedItems) {
+      existingButton?.remove();
+      row.classList.remove("bt-pinned");
+      row.removeAttribute("data-bt-pin-id");
+      return;
+    }
+
     const left = row.querySelector<HTMLElement>(".left");
     const id = row.dataset.id;
     if (!left || !id) return;
-    let button = left.querySelector<HTMLButtonElement>("button.bt-pin-button");
+    let button = existingButton;
     if (!button) {
       button = document.createElement("button");
       button.type = "button";
@@ -764,6 +779,12 @@ export class ItemResultsService {
     button.title = label;
     button.setAttribute("aria-label", label);
     row.dataset.btPinId = id;
+  }
+
+  private refreshPinButtons() {
+    document
+      .querySelectorAll<HTMLElement>(".search-results .result-item, .search-results .row, .result-list .result-item, .row")
+      .forEach((row) => this.syncPinButton(row));
   }
 
   private syncWikiButton(row: HTMLElement) {

--- a/lib/services/item-results.ts
+++ b/lib/services/item-results.ts
@@ -19,6 +19,7 @@ import {
 } from "../utilities/copy-item-for-craft-of-exile";
 import { flashMessages } from "./flash";
 import { experimentalSettings } from "./experimental";
+import { pinnedItemsService } from "./pinned-items";
 
 
 
@@ -660,7 +661,8 @@ export class ItemResultsService {
       this.syncCoeButton(typedRow);
       this.syncWikiButton(typedRow);
       this.injectEquivalentPricing(typedRow);
-      this.enhanceMagebloodLegacy(typedRow);
+       this.enhanceMagebloodLegacy(typedRow);
+       this.syncPinButton(typedRow);
 
       if (typedRow.hasAttribute("bt-enhanced")) {
         return;
@@ -715,6 +717,38 @@ export class ItemResultsService {
     } else {
       left.appendChild(button);
     }
+  }
+
+  private syncPinButton(row: HTMLElement) {
+    const left = row.querySelector<HTMLElement>(".left");
+    const id = row.dataset.id;
+    if (!left || !id) return;
+    let button = left.querySelector<HTMLButtonElement>("button.bt-pin-button");
+    if (!button) {
+      button = document.createElement("button");
+      button.type = "button";
+      button.className = "bt-pin-button";
+      button.addEventListener("click", (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        const title = row.querySelector<HTMLElement>(".itemName .itemHeader, .item-popup__header-line")?.textContent?.trim() || "Item";
+        pinnedItemsService.toggle({
+          id,
+          title,
+          detailsHtml: row.querySelector<HTMLElement>(".itemPopupContainer, .item-popup")?.outerHTML || "",
+          renderedHtml: row.querySelector<HTMLElement>(".item")?.outerHTML || "",
+          pricingHtml: row.querySelector<HTMLElement>("[data-field=price], .price")?.outerHTML || ""
+        });
+        this.syncPinButton(row);
+      });
+      left.appendChild(button);
+    }
+    const pinned = pinnedItemsService.has(id);
+    row.classList.toggle("bt-pinned", pinned);
+    button.textContent = pinned ? "Unpin" : "Pin";
+    button.title = button.textContent;
+    button.setAttribute("aria-label", button.textContent);
+    row.dataset.btPinId = id;
   }
 
   private syncWikiButton(row: HTMLElement) {

--- a/lib/services/pinned-items.ts
+++ b/lib/services/pinned-items.ts
@@ -1,4 +1,4 @@
-import { writable } from "svelte/store"
+import { get, writable } from "svelte/store"
 
 export interface PinnedItem {
   id: string
@@ -8,23 +8,18 @@ export interface PinnedItem {
   pricingHtml: string
 }
 
-const STORAGE_KEY = "poe-trade-plus:pinned-items"
-const read = (): PinnedItem[] => {
-  try { return JSON.parse(window.sessionStorage.getItem(STORAGE_KEY) || "[]") } catch { return [] }
-}
-const { subscribe, update } = writable<PinnedItem[]>(typeof window === "undefined" ? [] : read())
-const save = (items: PinnedItem[]) => window.sessionStorage.setItem(STORAGE_KEY, JSON.stringify(items))
+const store = writable<PinnedItem[]>([])
+const { subscribe, update } = store
 
 export const pinnedItemsService = {
   subscribe,
-  has(id: string) { return read().some((item) => item.id === id) },
+  has(id: string) { return get(store).some((item) => item.id === id) },
   toggle(item: PinnedItem) {
     update((items) => {
       const next = items.some((current) => current.id === item.id) ? items.filter((current) => current.id !== item.id) : [item, ...items]
-      save(next)
       return next
     })
   },
-  unpin(id: string) { update((items) => { const next = items.filter((item) => item.id !== id); save(next); return next }) },
-  clear() { save([]); update(() => []) }
+  unpin(id: string) { update((items) => items.filter((item) => item.id !== id)) },
+  clear() { update(() => []) }
 }

--- a/lib/services/pinned-items.ts
+++ b/lib/services/pinned-items.ts
@@ -1,0 +1,30 @@
+import { writable } from "svelte/store"
+
+export interface PinnedItem {
+  id: string
+  title: string
+  detailsHtml: string
+  renderedHtml: string
+  pricingHtml: string
+}
+
+const STORAGE_KEY = "poe-trade-plus:pinned-items"
+const read = (): PinnedItem[] => {
+  try { return JSON.parse(window.sessionStorage.getItem(STORAGE_KEY) || "[]") } catch { return [] }
+}
+const { subscribe, update } = writable<PinnedItem[]>(typeof window === "undefined" ? [] : read())
+const save = (items: PinnedItem[]) => window.sessionStorage.setItem(STORAGE_KEY, JSON.stringify(items))
+
+export const pinnedItemsService = {
+  subscribe,
+  has(id: string) { return read().some((item) => item.id === id) },
+  toggle(item: PinnedItem) {
+    update((items) => {
+      const next = items.some((current) => current.id === item.id) ? items.filter((current) => current.id !== item.id) : [item, ...items]
+      save(next)
+      return next
+    })
+  },
+  unpin(id: string) { update((items) => { const next = items.filter((item) => item.id !== id); save(next); return next }) },
+  clear() { save([]); update(() => []) }
+}

--- a/lib/services/settings.ts
+++ b/lib/services/settings.ts
@@ -27,6 +27,7 @@ export interface VersionSettings {
   showEquivalentPricing: boolean
   showMagebloodLegacyDescriptions: boolean
   showBulkSellers: boolean
+  showPinnedItems: boolean
   showHistory: boolean
   showFinerFilters: boolean
   showQuickFilters: boolean
@@ -70,6 +71,7 @@ const DEFAULT_VERSION_SETTINGS: VersionSettings = {
   showEquivalentPricing: false,
   showMagebloodLegacyDescriptions: true,
   showBulkSellers: false,
+  showPinnedItems: false,
   showHistory: true,
   showFinerFilters: true,
   showQuickFilters: true,
@@ -179,6 +181,7 @@ function legacyVersionSettings(
     showEquivalentPricing: value?.showEquivalentPricing,
     showMagebloodLegacyDescriptions: value?.showMagebloodLegacyDescriptions,
     showBulkSellers: value?.showBulkSellers,
+    showPinnedItems: value?.showPinnedItems,
     showHistory: value?.showHistory,
     showFinerFilters: value?.showFinerFilters,
     showQuickFilters: value?.showQuickFilters,
@@ -397,6 +400,9 @@ export const settings = {
   },
   async updateBulkSellersVisibility(showBulkSellers: boolean) {
     return saveVersion({ ...activeVersionSettings, showBulkSellers })
+  },
+  async updatePinnedItemsVisibility(showPinnedItems: boolean) {
+    return saveVersion({ ...activeVersionSettings, showPinnedItems })
   },
   async updateHistoryVisibility(showHistory: boolean) {
     return saveVersion({ ...activeVersionSettings, showHistory })

--- a/lib/styles/enhancements.css
+++ b/lib/styles/enhancements.css
@@ -180,8 +180,29 @@ body.bt-dev-result-actions-visible.bt-dev-wiki-visible
   }
 }
 .bt-pin-button {
-  min-width: 47px !important;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  min-width: 36px !important;
+  padding: 0;
   margin-left: 5px !important;
+  border: 0;
+  background: transparent;
+  color: rgba(238, 238, 238, 0.78);
+  cursor: pointer;
+}
+.bt-pin-button svg {
+  width: 21px;
+  height: 21px;
+  stroke-width: 1.65;
+  pointer-events: none;
+}
+.bt-pin-button:hover,
+.bt-pin-button:focus-visible {
+  color: #c4b18c;
+  outline: none;
 }
 
 .bt-pinned {

--- a/lib/styles/enhancements.css
+++ b/lib/styles/enhancements.css
@@ -181,22 +181,27 @@ body.bt-dev-result-actions-visible.bt-dev-wiki-visible
 }
 .bt-pin-button {
   display: inline-flex;
+  position: absolute;
+  top: 4px;
+  right: auto;
+  left: 42px;
+  z-index: 4;
   align-items: center;
   justify-content: center;
   width: 36px;
   height: 36px;
   min-width: 36px !important;
   padding: 0;
-  margin-left: 5px !important;
+  margin: 0 !important;
   border: 0;
   background: transparent;
-  color: rgba(238, 238, 238, 0.78);
+  color: #ffffff;
   cursor: pointer;
 }
 .bt-pin-button svg {
   width: 21px;
   height: 21px;
-  stroke-width: 1.65;
+  stroke-width: 2.8;
   pointer-events: none;
 }
 .bt-pin-button:hover,

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "poe-trade-plus",
   "displayName": "Poe Trade Plus",
-  "version": "1.1.17",
+  "version": "1.1.18",
   "packageManager": "pnpm@11.3.0",
   "license": "MIT",
   "description": "Poe Trade Plus enhances the Path of Exile trade site with bookmarks, history and result tools.",


### PR DESCRIPTION
# v1.1.18

## 1.1.18
### New features
- **Pinned items return** — Reimplemented from the original Better Trading workflow, optional pins keep a result available during the current search and let you jump back to it from the sidebar.

## 1.1.17
### New features
- **Sync bookmarks and settings across devices** — Bookmarks, bookmark folders, and extension settings now follow your signed-in browser profile. Existing data is safely migrated when you update.

## 1.1.16
### Fixes
- **Medium text size works correctly** — Selecting Medium in General settings now keeps your preferred text size after the extension reloads.

## 1.1.14
### New features
- **Middle-click folders to open saved searches** — Middle-click a bookmark folder to open all its saved searches in background tabs.

## 1.1.13
### New features
- **Kakao Games trade site support** — The sidebar and trade helpers now work on poe.kakaogames.com for both PoE1 (/trade) and PoE2 (/trade2).

## 1.1.12
### Fixes
- **Middle-click no longer enables auto-scroll** — Middle-clicking a saved search opens it in a background tab without activating the browser's auto-scroll cursor.

## 1.1.11
### New features
- **Guided tutorial refreshed** — The tutorial now follows the main workflows, groups related settings together, and keeps its guide cards out of the way of the controls they explain.
- **Bookmark Layout preview matches the real list** — The live preview now uses the real folder and bookmark components, including categories, two example searches, and the layout-specific action placement.

## 1.1.10
### New features
- **Open saved searches in new tabs** — Middle-click a saved search to open it in a background tab, so you can queue several searches without leaving the current one.
- **Bookmark icons are easier to browse** — The folder icon picker now groups currency and ascendancy icons, making the right icon faster to find.
- **Sidebar preferences are more reliable** — Sidebar defaults are shared consistently, and the Path of Building copy action remains visible where it is available on PoE2.

## 1.1.9
### Fixes
- **Bookmarks update more reliably** — Saved bookmark changes now validate stored data before updating the sidebar, preventing malformed or outdated storage entries from causing problems.
- **Cleaner Bookmark Layout preview** — The live Bookmark Layout preview no longer shows a league label, keeping the sample focused on the layout and actions.

## 1.1.8
### New features
- **Optional desecrated mods in Craft of Exile exports** — Craft of Exile exports now exclude desecrated mods by default. You can opt in from Results settings to include them as normal modifiers, with a warning that Craft of Exile does not yet support importing them.

## 1.1.7
### New features
- **Bookmarks follow active trade realm** — Saved searches now open in the active trade tab's current league and realm, while keeping their saved league as a fallback.
- **Clear Buyout Price shortcut** — Quick Filter Presets now include a Clear button that resets Buyout Price to Chaos Orb Equivalent and works with supported trade-site languages.

## 1.1.6
### New features
- **Wiki button for unique items** — Results can now show an optional W action on unique items that opens the matching PoE Wiki or PoE2 Wiki page.
- **Minimal bookmark layout** — Bookmarks now offer Classic, Compact, and Minimal layouts. Minimal keeps rows dense without changing the Path of Exile look.
- **Actions saved per layout** — Choose visible bookmark actions independently for Classic, Compact, and Minimal. Settings and preview update together.

## 1.1.5
### New features
- **Bookmark categories inside folders** — Saved searches can now be grouped into optional categories inside each bookmark folder. The feature is off by default, and turning it off returns every bookmark to the main folder list.
- **Cleaner bookmark action menus** — Category assignment, category creation, and category deletion now live inside the bookmark action menu, with inline creation and the same delete confirmation modal used elsewhere.

### Polish
- **Settings are more compact** — Long setting descriptions now appear as hover help, reducing visual clutter while keeping the details available when you need them.
- **General settings are clearer** — The Interface tab is now General, and Backup & Restore lives there alongside the other extension-wide options.

## 1.1.4
### New features
- **Adjustable text size** — Interface settings now include Small, Medium, Large, and Extra text sizes, with Large as the default.
- **Tutorial access moved to About** — The button to reopen the onboarding tutorial now lives in About, keeping Interface settings focused on display and language options.

## 1.1.3
### New features
- **Full extension backup** — Backup files now include saved folders, searches, global settings, PoE1/PoE2 result settings, and extension preferences in one portable JSON file.
- **Old folder backups still restore** — The restore action still accepts older folder-only .txt exports, so existing backups remain usable.

## 1.1.2
### New features
- **External reference links in the popup** — The popup can now show grouped PoE1 and PoE2 shortcuts for the official trade-adjacent tools, including the Path of Exile Wiki, Path of Exile 2 Wiki, Path of Regex, Craft of Exile, PoEDb, PoE2Db, and poe.ninja.
- **New PoE2 bookmark folder icons** — Disciple of Varashta, Martial Artist, and Spirit Walker icons are available for PoE2 bookmark folders.
- **Mageblood Legacy descriptions for PoE2** — A new Results setting can show hidden Mageblood Legacy effects below PoE2 item results, including duplicate Legacy scaling.

### Fixes
- **Localized PoE2 trade links load correctly** — Bookmarks and helper panels now recognize localized trade2 hosts such as es.pathofexile.com and keep league URLs with spaces encoded correctly.
- **Mageblood Legacy works across languages** — Legacy detection now uses stable trade stat ids, with localized effect descriptions for English, Spanish, Portuguese, Russian, Thai, German, French, Japanese, and Korean.

### Polish
- **Mageblood details stay quiet until hover** — Legacy descriptions show the final value by default, while base value and duplicate effect details appear inline on hover.
- **Mageblood descriptions match item layout** — Legacy description blocks now sit below corrupt/explicit separators like native notable descriptions and stay out of copied item text.

## 1.1.1
### Fixes
- **Foulborn items add the correct modifier** — Quick filter buttons now compensate for mutated Foulborn item rows where the trade site shifts modifier stat ids out of visual order.
- **Bookmark action buttons no longer open searches** — Editing, refreshing, duplicating, or opening the bookmark menu stays inside that action instead of triggering the saved search row.
- **PoE2 copy stays out of PoE1** — The Path of Building copy option is now only shown on the PoE2 trade site.
- **Craft of Exile buttons keep their shape** — The CoE action button is now a centered 30px square so it aligns cleanly with the result row controls.

### Polish
- **Craft of Exile copy avoids unsupported modifier slots** — Items with Prefix/Suffix Modifier allowed affixes now show a greyed CoE button with an explanation, while Copy for PoB keeps working.
- **Version-specific settings are clearer** — PoE1 and PoE2 can keep separate result-tool preferences where that matters, and PoE2-only tools stay hidden on PoE1.

## 1.1.0
### New features
- **Settings are now easier to navigate** — Customization is grouped into Interface, Sidebar, Results, and Bookmarks so each option has a clearer home.
- **Bookmark Layout now has a live preview** — The Bookmarks settings tab shows a real-time saved-search preview using the same action menu as the actual bookmark list.
- **What's New is now built into the sidebar** — New releases can show a compact update prompt, plus a full release notes modal from About.
- **Quick Filter Presets can live where you work** — Enable them from Results settings, then choose whether they appear in the sidebar or directly above the trade site's Stat Filters.
- **Craft of Exile export is easier to reach** — PoE1 and PoE2 result rows can now expose a CoE action that copies items in Craft of Exile's advanced import format.
- **PoE2 copy support for Path of Building** — A dedicated PoE2 copy option can surface beside other result actions and copy item text ready for PoB.
- **Equivalent pricing works across both games** — poe.ninja ratios now support PoE1 and PoE2 so chaos/divine conversion stays useful on either trade site.

### Polish
- **Sidebar and result options were separated** — Visible sidebar modules now live under Sidebar, while injected trade-result tools stay under Results.
- **Add To Filters moved out of the sidebar by default** — Quick filter presets can now be injected into the trade page, keeping the sidebar focused on navigation and saved searches.
- **Bookmark folders remember their open state** — Expanded and collapsed folders persist more predictably across sessions.
- **History labels and trade URLs are cleaner** — League names, fallbacks, and trade-link handling received small consistency improvements.
- **Result cards are easier to use** — Card click handling and seller panel accessibility were tightened for repeated trade workflows.

### Fixes
- **More reliable background messaging** — Background requests and bulk seller caching now handle failure cases more defensively.
- **Finer Filters hover behavior is smoother** — Compact result layouts and item filter buttons now behave more consistently.
- **Bookmark text opens saved searches again** — Clicking the saved-search title now opens the bookmark instead of being ignored.
- **Extension dependencies were hardened** — Dependency overrides and validation changes reduce known package and request risks.
