### PR TITLE
Release v1.1.19

### DIFF
--- a/Chrome.md
+++ b/Chrome.md
@@ -24,7 +24,8 @@
 • Highlight active stat filters directly in search results
 • Adjust quick filters, including a shortcut to clear Buyout Price
 • Show socket breakpoint warnings for armour items
-• Navigate pinned results and auto-scroll back to the selected item
+• Enable the optional Pinned Items tab to keep results from the current search close at hand and jump back to them with one click
+• Pins are cleared automatically when you start a new search or reload the page, so the list never carries stale results
 • Use integrated Finer Filters for fast stat modifications
 • Open matching PoE Wiki or PoE2 Wiki pages for unique items
 • Show optional Mageblood Legacy descriptions for PoE2 in every supported interface language

--- a/components/BookmarkFolder.svelte
+++ b/components/BookmarkFolder.svelte
@@ -1025,6 +1025,7 @@
                             onEdit={() => void startEditingTrade(trade)}
                             onReplace={() => void replaceSearchWithCurrent(trade)}
                             onCopy={() => copyTrade(trade)}
+                            onDuplicate={() => void duplicateTrade(trade)}
                             onOpenLive={() => void openTradeLive(trade)}
                             onToggle={() => void toggleTrade(trade)}
                             onDelete={() => requestTradeDelete(trade)}
@@ -1043,6 +1044,7 @@
                           onEdit={() => void startEditingTrade(trade)}
                           onReplace={() => void replaceSearchWithCurrent(trade)}
                           onCopy={() => copyTrade(trade)}
+                          onDuplicate={() => void duplicateTrade(trade)}
                           onOpenLive={() => void openTradeLive(trade)}
                           onToggle={() => void toggleTrade(trade)}
                           onDelete={() => requestTradeDelete(trade)}

--- a/components/TradeActionsMenu.svelte
+++ b/components/TradeActionsMenu.svelte
@@ -11,7 +11,8 @@
 
   import editIcon from "lucide-static/icons/pencil.svg?raw";
   import replaceIcon from "lucide-static/icons/refresh-cw.svg?raw";
-  import copyIcon from "lucide-static/icons/copy.svg?raw";
+  import linkIcon from "lucide-static/icons/link.svg?raw";
+  import duplicateIcon from "lucide-static/icons/copy.svg?raw";
   import liveIcon from "lucide-static/icons/activity.svg?raw";
   import checkIcon from "lucide-static/icons/check.svg?raw";
   import trashIcon from "lucide-static/icons/trash-2.svg?raw";
@@ -22,6 +23,7 @@
     onEdit: () => void;
     onReplace: () => void;
     onCopy: () => void;
+    onDuplicate: () => void;
     onOpenLive: () => void;
     onToggle: () => void;
     onDelete: () => void;
@@ -38,6 +40,7 @@
     onEdit,
     onReplace,
     onCopy,
+    onDuplicate,
     onOpenLive,
     onToggle,
     onDelete,
@@ -62,6 +65,7 @@
     "edit",
     "replace",
     "copy",
+    "duplicate",
     "openLive",
     "toggle",
     "delete"
@@ -86,9 +90,15 @@
     },
     {
       id: "copy",
-      icon: copyIcon,
+      icon: linkIcon,
       label: translate($languageStore, "folder.copyUrl"),
       handler: onCopy
+    },
+    {
+      id: "duplicate",
+      icon: duplicateIcon,
+      label: translate($languageStore, "folder.duplicateTrade"),
+      handler: onDuplicate
     },
     {
       id: "openLive",

--- a/components/pages/Settings.svelte
+++ b/components/pages/Settings.svelte
@@ -31,7 +31,8 @@
   import flagTH from "../../assets/TH.png?inline";
   import editIcon from "lucide-static/icons/pencil.svg?raw";
   import replaceIcon from "lucide-static/icons/refresh-cw.svg?raw";
-  import copyIcon from "lucide-static/icons/copy.svg?raw";
+  import linkIcon from "lucide-static/icons/link.svg?raw";
+  import duplicateIcon from "lucide-static/icons/copy.svg?raw";
   import liveIcon from "lucide-static/icons/activity.svg?raw";
   import toggleIcon from "lucide-static/icons/check.svg?raw";
   import deleteIcon from "lucide-static/icons/trash-2.svg?raw";
@@ -63,7 +64,8 @@
   const compactTradeActionOptions: Array<{ id: BookmarkTradeActionId; labelKey: string; icon: string }> = [
     { id: "edit", labelKey: "folder.editSearchName", icon: editIcon },
     { id: "replace", labelKey: "folder.replaceCurrentSearch", icon: replaceIcon },
-    { id: "copy", labelKey: "folder.copyUrl", icon: copyIcon },
+    { id: "copy", labelKey: "folder.copyUrl", icon: linkIcon },
+    { id: "duplicate", labelKey: "folder.duplicateTrade", icon: duplicateIcon },
     { id: "openLive", labelKey: "folder.openLiveSearch", icon: liveIcon },
     { id: "toggle", labelKey: "settings.compactTradeActionToggle", icon: toggleIcon },
     { id: "delete", labelKey: "folder.deleteTrade", icon: deleteIcon }

--- a/lib/data/whats-new.ts
+++ b/lib/data/whats-new.ts
@@ -109,6 +109,13 @@ const version1118Features: WhatsNewItem[] = [
   }
 ];
 
+const version1119Features: WhatsNewItem[] = [
+  {
+    titleKey: "whatsNew.item.duplicateBookmarksTitle",
+    descriptionKey: "whatsNew.item.duplicateBookmarksDescription"
+  }
+];
+
 const version112Features: WhatsNewItem[] = [
   {
     title: "External reference links in the popup",
@@ -361,9 +368,18 @@ const version1110Features: WhatsNewItem[] = [
 ];
 
 export const latestWhatsNew: WhatsNewEntry = {
-  version: "1.1.18",
-  date: "2026-07-26",
+  version: "1.1.19",
+  date: "2026-08-01",
   sections: [
+    {
+      title: "1.1.19",
+      groups: [
+        {
+          titleKey: "whatsNew.section.features",
+          items: version1119Features
+        }
+      ]
+    },
     {
       title: "1.1.18",
       groups: [

--- a/lib/services/i18n/de.ts
+++ b/lib/services/i18n/de.ts
@@ -203,6 +203,7 @@ export const germanTranslations: Record<string, TranslationValue> = {
   "folder.copiedTrade": ({ title }) => `${title} in die Zwischenablage kopiert`,
   "folder.copyTradeError": "Die Trade-URL konnte nicht kopiert werden.",
   "folder.duplicatedTrade": ({ title }) => `${title} dupliziert`,
+  "folder.duplicateTrade": "Lesezeichen duplizieren",
   "folder.invalidTradePage": "Keine gültige Trade-Seite geöffnet",
   "folder.missingTradeType": "Für die aktuelle Suche fehlt der Trade-Typ.",
   "folder.addedToFolder": ({ title }) => `"${title}" zum Ordner hinzugefügt`,

--- a/lib/services/i18n/de.ts
+++ b/lib/services/i18n/de.ts
@@ -269,6 +269,8 @@ export const germanTranslations: Record<string, TranslationValue> = {
   "pinned.sessionNote": "Angeheftete Gegenstände werden bei einer neuen Suche oder beim Neuladen der Seite entfernt.",
   "whatsNew.item.pinnedItemsTitle": "Angeheftete Gegenstände sind zurück",
   "whatsNew.item.pinnedItemsDescription": "Nach dem ursprünglichen Better-Trading-Ablauf neu umgesetzt: Optionale Pins halten ein Ergebnis während der aktuellen Suche verfügbar und springen über die Seitenleiste dorthin zurück.",
+  "whatsNew.item.duplicateBookmarksTitle": "Lesezeichen direkt duplizieren",
+  "whatsNew.item.duplicateBookmarksDescription": "Gespeicherte Suchen bieten jetzt Lesezeichen duplizieren, damit du eine Kopie ohne erneutes Erstellen der Suche anlegen kannst.",
   "whatsNew.item.buyoutClearTitle": "Schnellaktion zum Leeren des Kaufpreises",
   "whatsNew.item.buyoutClearDescription":
     "Schnellfilter-Voreinstellungen enthalten jetzt eine Schaltfläche zum Leeren, die den Kaufpreis auf Wert in Chaossphären setzt und mit unterstützten Trade-Website-Sprachen funktioniert.",

--- a/lib/services/i18n/en.ts
+++ b/lib/services/i18n/en.ts
@@ -408,6 +408,7 @@ export const englishTranslations: Record<string, TranslationValue> = {
   "folder.copiedTrade": ({ title }) => `Copied ${title} to clipboard`,
   "folder.copyTradeError": "Couldn't copy the trade URL.",
   "folder.duplicatedTrade": ({ title }) => `Duplicated ${title}`,
+  "folder.duplicateTrade": "Duplicate bookmark",
   "folder.invalidTradePage": "Not on a valid trade page",
   "folder.missingTradeType": "Missing trade type for the current search.",
   "folder.addedToFolder": ({ title }) => `Added "${title}" to folder`,

--- a/lib/services/i18n/en.ts
+++ b/lib/services/i18n/en.ts
@@ -481,6 +481,8 @@ export const englishTranslations: Record<string, TranslationValue> = {
   "pinned.sessionNote": "Pinned items are cleared when you start a new search or reload the page.",
   "whatsNew.item.pinnedItemsTitle": "Pinned items return",
   "whatsNew.item.pinnedItemsDescription": "Reimplemented from the original Better Trading workflow, optional pins keep a result available during the current search and let you jump back to it from the sidebar.",
+  "whatsNew.item.duplicateBookmarksTitle": "Duplicate bookmarks directly",
+  "whatsNew.item.duplicateBookmarksDescription": "Saved-search actions now include Duplicate bookmark, so you can make a copy without recreating the search.",
   "whatsNew.item.buyoutClearTitle": "Clear Buyout Price shortcut",
   "whatsNew.item.buyoutClearDescription":
     "Quick Filter Presets now include a Clear button that resets Buyout Price to Chaos Orb Equivalent and works with supported trade-site languages."

--- a/lib/services/i18n/es.ts
+++ b/lib/services/i18n/es.ts
@@ -490,6 +490,8 @@ export const spanishTranslations: Record<string, TranslationValue> = {
   "pinned.sessionNote": "Los objetos fijados se eliminan al iniciar una búsqueda nueva o recargar la página.",
   "whatsNew.item.pinnedItemsTitle": "Vuelven los objetos fijados",
   "whatsNew.item.pinnedItemsDescription": "Reimplementados a partir del flujo original de Better Trading, los pins opcionales mantienen un resultado disponible durante la búsqueda actual y permiten volver a él desde la barra lateral.",
+  "whatsNew.item.duplicateBookmarksTitle": "Duplicá bookmarks directamente",
+  "whatsNew.item.duplicateBookmarksDescription": "Las acciones de búsqueda guardada ahora incluyen Duplicar bookmark para crear una copia sin volver a armar la búsqueda.",
   "whatsNew.item.buyoutClearTitle": "Acceso rápido para limpiar el precio de compra",
   "whatsNew.item.buyoutClearDescription":
     "Los ajustes preestablecidos de filtro rápido ahora incluyen un botón Limpiar que restablece Precio de compra a Equivalente a Orbe de caos y funciona en los idiomas compatibles del sitio de trade."

--- a/lib/services/i18n/es.ts
+++ b/lib/services/i18n/es.ts
@@ -415,6 +415,7 @@ export const spanishTranslations: Record<string, TranslationValue> = {
   "folder.copiedTrade": ({ title }) => `Se copió ${title} al portapapeles`,
   "folder.copyTradeError": "No se pudo copiar la URL del trade.",
   "folder.duplicatedTrade": ({ title }) => `Se duplicó ${title}`,
+  "folder.duplicateTrade": "Duplicar bookmark",
   "folder.invalidTradePage": "No estás en una página válida de trade",
   "folder.missingTradeType": "Falta el tipo de trade para la búsqueda actual.",
   "folder.addedToFolder": ({ title }) => `Se agregó "${title}" a la carpeta`,

--- a/lib/services/i18n/fr.ts
+++ b/lib/services/i18n/fr.ts
@@ -274,6 +274,8 @@ export const frenchTranslations: Record<string, TranslationValue> = {
   "pinned.sessionNote": "Les objets épinglés sont supprimés lors d'une nouvelle recherche ou du rechargement de la page.",
   "whatsNew.item.pinnedItemsTitle": "Les objets épinglés reviennent",
   "whatsNew.item.pinnedItemsDescription": "Réimplémentés depuis le flux original de Better Trading, les épingles facultatives gardent un résultat disponible pendant la recherche et permettent d'y revenir depuis la barre latérale.",
+  "whatsNew.item.duplicateBookmarksTitle": "Dupliquez les favoris directement",
+  "whatsNew.item.duplicateBookmarksDescription": "Les actions de recherche enregistrée incluent maintenant Dupliquer le favori, pour créer une copie sans recréer la recherche.",
   "whatsNew.item.buyoutClearTitle": "Raccourci pour effacer le prix de rachat",
   "whatsNew.item.buyoutClearDescription":
     "Les préréglages de filtre rapide incluent désormais un bouton Effacer qui règle le prix de rachat sur Équivalent en orbes du chaos et fonctionne avec les langues prises en charge du site trade.",

--- a/lib/services/i18n/fr.ts
+++ b/lib/services/i18n/fr.ts
@@ -206,6 +206,7 @@ export const frenchTranslations: Record<string, TranslationValue> = {
   "folder.copiedTrade": ({ title }) => `${title} copié dans le presse-papiers`,
   "folder.copyTradeError": "Impossible de copier l’URL du trade.",
   "folder.duplicatedTrade": ({ title }) => `${title} dupliqué`,
+  "folder.duplicateTrade": "Dupliquer le favori",
   "folder.invalidTradePage": "Vous n’êtes pas sur une page de trade valide",
   "folder.missingTradeType":
     "Le type de trade est manquant pour la recherche actuelle.",

--- a/lib/services/i18n/ja.ts
+++ b/lib/services/i18n/ja.ts
@@ -207,6 +207,7 @@ export const japaneseTranslations: Record<string, TranslationValue> = {
     `${title} をクリップボードにコピーしました`,
   "folder.copyTradeError": "トレード URL をコピーできませんでした。",
   "folder.duplicatedTrade": ({ title }) => `${title} を複製しました`,
+  "folder.duplicateTrade": "ブックマークを複製",
   "folder.invalidTradePage": "有効なトレードページではありません",
   "folder.missingTradeType": "現在の検索にトレードタイプがありません。",
   "folder.addedToFolder": ({ title }) =>

--- a/lib/services/i18n/ja.ts
+++ b/lib/services/i18n/ja.ts
@@ -277,6 +277,8 @@ export const japaneseTranslations: Record<string, TranslationValue> = {
   "pinned.sessionNote": "新しい検索を開始するかページを再読み込みすると、固定したアイテムは削除されます。",
   "whatsNew.item.pinnedItemsTitle": "固定したアイテムが復活",
   "whatsNew.item.pinnedItemsDescription": "Better Trading の元のフローをもとに再実装しました。任意の固定で現在の検索中に結果を残し、サイドバーからその結果へ戻れます。",
+  "whatsNew.item.duplicateBookmarksTitle": "ブックマークを直接複製",
+  "whatsNew.item.duplicateBookmarksDescription": "保存した検索のアクションにブックマークを複製が追加され、検索を作り直さずにコピーを作成できます。",
   "whatsNew.item.buyoutClearTitle": "バイアウト価格をクリアするショートカット",
   "whatsNew.item.buyoutClearDescription":
     "クイックフィルタープリセットに、バイアウト価格をカオスオーブ同等物へ戻すクリアボタンが追加され、対応するTradeサイトの言語で動作します。",

--- a/lib/services/i18n/ko.ts
+++ b/lib/services/i18n/ko.ts
@@ -274,6 +274,8 @@ export const koreanTranslations: Record<string, TranslationValue> = {
   "pinned.sessionNote": "새 검색을 시작하거나 페이지를 새로 고치면 고정한 아이템이 제거됩니다.",
   "whatsNew.item.pinnedItemsTitle": "고정한 아이템이 돌아왔습니다",
   "whatsNew.item.pinnedItemsDescription": "원본 Better Trading 흐름을 바탕으로 다시 구현했습니다. 선택적인 고정으로 현재 검색 중 결과를 유지하고 사이드바에서 해당 결과로 돌아갈 수 있습니다.",
+  "whatsNew.item.duplicateBookmarksTitle": "북마크를 바로 복제",
+  "whatsNew.item.duplicateBookmarksDescription": "저장된 검색 작업에 북마크 복제가 추가되어 검색을 다시 만들지 않고 사본을 만들 수 있습니다.",
   "whatsNew.item.buyoutClearTitle": "즉시 구매 가격 지우기 단축키",
   "whatsNew.item.buyoutClearDescription":
     "빠른 필터 프리셋에 즉시 구매 가격을 카오스 오브 등가물로 설정하는 지우기 버튼이 추가되었으며, 지원되는 Trade 사이트 언어에서 작동합니다.",

--- a/lib/services/i18n/ko.ts
+++ b/lib/services/i18n/ko.ts
@@ -205,6 +205,7 @@ export const koreanTranslations: Record<string, TranslationValue> = {
   "folder.copiedTrade": ({ title }) => `${title}을(를) 클립보드에 복사했습니다`,
   "folder.copyTradeError": "거래 URL을 복사할 수 없습니다.",
   "folder.duplicatedTrade": ({ title }) => `${title}을(를) 복제했습니다`,
+  "folder.duplicateTrade": "북마크 복제",
   "folder.invalidTradePage": "유효한 거래 페이지가 아닙니다",
   "folder.missingTradeType": "현재 검색에 거래 유형이 없습니다.",
   "folder.addedToFolder": ({ title }) => `"${title}"을(를) 폴더에 추가했습니다`,

--- a/lib/services/i18n/pt.ts
+++ b/lib/services/i18n/pt.ts
@@ -280,6 +280,8 @@ export const portugueseTranslations: Record<string, TranslationValue> = {
   "pinned.sessionNote": "Os itens fixados são removidos ao iniciar uma nova busca ou recarregar a página.",
   "whatsNew.item.pinnedItemsTitle": "Itens fixados retornam",
   "whatsNew.item.pinnedItemsDescription": "Reimplementados a partir do fluxo original do Better Trading, os pins opcionais mantêm um resultado disponível durante a busca atual e permitem voltar a ele pela barra lateral.",
+  "whatsNew.item.duplicateBookmarksTitle": "Duplique marcadores diretamente",
+  "whatsNew.item.duplicateBookmarksDescription": "As ações de busca salva agora incluem Duplicar marcador para criar uma cópia sem recriar a busca.",
   "whatsNew.item.buyoutClearTitle": "Atalho para limpar o preço de compra",
   "whatsNew.item.buyoutClearDescription":
     "Os presets de filtro rápido agora incluem um botão Limpar que redefine Preço de Compra para Equivalente a Orbe do Caos e funciona nos idiomas compatíveis do site de trade.",

--- a/lib/services/i18n/pt.ts
+++ b/lib/services/i18n/pt.ts
@@ -208,6 +208,7 @@ export const portugueseTranslations: Record<string, TranslationValue> = {
     `${title} copiado para a área de transferência`,
   "folder.copyTradeError": "Não foi possível copiar a URL do trade.",
   "folder.duplicatedTrade": ({ title }) => `${title} duplicado`,
+  "folder.duplicateTrade": "Duplicar marcador",
   "folder.invalidTradePage": "Você não está em uma página de trade válida",
   "folder.missingTradeType": "Falta o tipo de trade para a busca atual.",
   "folder.addedToFolder": ({ title }) => `"${title}" foi adicionado à pasta`,

--- a/lib/services/i18n/ru.ts
+++ b/lib/services/i18n/ru.ts
@@ -267,6 +267,8 @@ export const russianTranslations: Record<string, TranslationValue> = {
   "pinned.sessionNote": "Закрепленные предметы удаляются при новом поиске или перезагрузке страницы.",
   "whatsNew.item.pinnedItemsTitle": "Закрепленные предметы вернулись",
   "whatsNew.item.pinnedItemsDescription": "Повторно реализованные по исходному потоку Better Trading, необязательные закрепления сохраняют результат во время текущего поиска и позволяют вернуться к нему из боковой панели.",
+  "whatsNew.item.duplicateBookmarksTitle": "Дублируйте закладки напрямую",
+  "whatsNew.item.duplicateBookmarksDescription": "В действиях сохраненного поиска теперь есть Дублировать закладку, чтобы создать копию без повторного создания поиска.",
   "whatsNew.item.buyoutClearTitle": "Быстрая очистка цены выкупа",
   "whatsNew.item.buyoutClearDescription":
     "В быстрых фильтрах теперь есть кнопка «Очистить», которая переключает цену выкупа на эквивалент сферы хаоса и работает с поддерживаемыми языками сайта trade.",

--- a/lib/services/i18n/ru.ts
+++ b/lib/services/i18n/ru.ts
@@ -200,6 +200,7 @@ export const russianTranslations: Record<string, TranslationValue> = {
   "folder.copiedTrade": ({ title }) => `${title} скопирован в буфер обмена`,
   "folder.copyTradeError": "Не удалось скопировать URL трейда.",
   "folder.duplicatedTrade": ({ title }) => `${title} дублирован`,
+  "folder.duplicateTrade": "Дублировать закладку",
   "folder.invalidTradePage": "Вы не на действительной странице трейда",
   "folder.missingTradeType": "Отсутствует тип трейда для текущего поиска.",
   "folder.addedToFolder": ({ title }) => `"${title}" добавлен в папку`,

--- a/lib/services/i18n/th.ts
+++ b/lib/services/i18n/th.ts
@@ -199,6 +199,7 @@ export const thaiTranslations: Record<string, TranslationValue> = {
   "folder.copiedTrade": ({ title }) => `คัดลอก ${title} ไปยังคลิปบอร์ดแล้ว`,
   "folder.copyTradeError": "ไม่สามารถคัดลอก URL ของ trade ได้",
   "folder.duplicatedTrade": ({ title }) => `คัดลอก ${title} แล้ว`,
+  "folder.duplicateTrade": "ทำซ้ำบุ๊กมาร์ก",
   "folder.invalidTradePage": "ไม่ได้อยู่ในหน้าการเทรดที่ถูกต้อง",
   "folder.missingTradeType": "ไม่มีประเภท trade สำหรับการค้นหาปัจจุบัน",
   "folder.addedToFolder": ({ title }) => `เพิ่ม "${title}" ไปยังโฟลเดอร์แล้ว`,

--- a/lib/services/i18n/th.ts
+++ b/lib/services/i18n/th.ts
@@ -266,6 +266,8 @@ export const thaiTranslations: Record<string, TranslationValue> = {
   "pinned.sessionNote": "ไอเท็มที่ปักหมุดจะถูกลบเมื่อเริ่มการค้นหาใหม่หรือรีโหลดหน้า",
   "whatsNew.item.pinnedItemsTitle": "ไอเท็มที่ปักหมุดกลับมาแล้ว",
   "whatsNew.item.pinnedItemsDescription": "นำกลับมาใช้ใหม่จากขั้นตอนดั้งเดิมของ Better Trading โดยหมุดที่เลือกใช้ได้จะเก็บผลลัพธ์ไว้ระหว่างการค้นหาปัจจุบันและกลับไปยังผลลัพธ์นั้นจากแถบด้านข้างได้",
+  "whatsNew.item.duplicateBookmarksTitle": "ทำซ้ำบุ๊กมาร์กได้โดยตรง",
+  "whatsNew.item.duplicateBookmarksDescription": "การทำงานของการค้นหาที่บันทึกไว้มีตัวเลือกทำซ้ำบุ๊กมาร์กแล้ว จึงสร้างสำเนาได้โดยไม่ต้องสร้างการค้นหาใหม่",
   "whatsNew.item.buyoutClearTitle": "ปุ่มล้างราคาซื้อทันที",
   "whatsNew.item.buyoutClearDescription":
     "พรีเซ็ตตัวกรองด่วนมีปุ่มล้างที่ตั้งราคาซื้อทันทีเป็นเทียบเป็น Chaos Orb และใช้ได้กับภาษาของเว็บไซต์ trade ที่รองรับ.",

--- a/lib/services/settings.ts
+++ b/lib/services/settings.ts
@@ -9,6 +9,7 @@ export type BookmarkTradeActionId =
   | "edit"
   | "replace"
   | "copy"
+  | "duplicate"
   | "openLive"
   | "toggle"
   | "delete"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "poe-trade-plus",
   "displayName": "Poe Trade Plus",
-  "version": "1.1.18",
+  "version": "1.1.19",
   "packageManager": "pnpm@11.3.0",
   "license": "MIT",
   "description": "Poe Trade Plus enhances the Path of Exile trade site with bookmarks, history and result tools.",


### PR DESCRIPTION
# v1.1.19

## 1.1.19
### New features
- **Duplicate bookmarks directly** — Saved-search actions now include Duplicate bookmark, so you can make a copy without recreating the search.

## 1.1.18
### New features
- **Pinned items return** — Reimplemented from the original Better Trading workflow, optional pins keep a result available during the current search and let you jump back to it from the sidebar.

## 1.1.17
### New features
- **Sync bookmarks and settings across devices** — Bookmarks, bookmark folders, and extension settings now follow your signed-in browser profile. Existing data is safely migrated when you update.

## 1.1.16
### Fixes
- **Medium text size works correctly** — Selecting Medium in General settings now keeps your preferred text size after the extension reloads.

## 1.1.14
### New features
- **Middle-click folders to open saved searches** — Middle-click a bookmark folder to open all its saved searches in background tabs.

## 1.1.13
### New features
- **Kakao Games trade site support** — The sidebar and trade helpers now work on poe.kakaogames.com for both PoE1 (/trade) and PoE2 (/trade2).

## 1.1.12
### Fixes
- **Middle-click no longer enables auto-scroll** — Middle-clicking a saved search opens it in a background tab without activating the browser's auto-scroll cursor.

## 1.1.11
### New features
- **Guided tutorial refreshed** — The tutorial now follows the main workflows, groups related settings together, and keeps its guide cards out of the way of the controls they explain.
- **Bookmark Layout preview matches the real list** — The live preview now uses the real folder and bookmark components, including categories, two example searches, and the layout-specific action placement.

## 1.1.10
### New features
- **Open saved searches in new tabs** — Middle-click a saved search to open it in a background tab, so you can queue several searches without leaving the current one.
- **Bookmark icons are easier to browse** — The folder icon picker now groups currency and ascendancy icons, making the right icon faster to find.
- **Sidebar preferences are more reliable** — Sidebar defaults are shared consistently, and the Path of Building copy action remains visible where it is available on PoE2.

## 1.1.9
### Fixes
- **Bookmarks update more reliably** — Saved bookmark changes now validate stored data before updating the sidebar, preventing malformed or outdated storage entries from causing problems.
- **Cleaner Bookmark Layout preview** — The live Bookmark Layout preview no longer shows a league label, keeping the sample focused on the layout and actions.

## 1.1.8
### New features
- **Optional desecrated mods in Craft of Exile exports** — Craft of Exile exports now exclude desecrated mods by default. You can opt in from Results settings to include them as normal modifiers, with a warning that Craft of Exile does not yet support importing them.

## 1.1.7
### New features
- **Bookmarks follow active trade realm** — Saved searches now open in the active trade tab's current league and realm, while keeping their saved league as a fallback.
- **Clear Buyout Price shortcut** — Quick Filter Presets now include a Clear button that resets Buyout Price to Chaos Orb Equivalent and works with supported trade-site languages.

## 1.1.6
### New features
- **Wiki button for unique items** — Results can now show an optional W action on unique items that opens the matching PoE Wiki or PoE2 Wiki page.
- **Minimal bookmark layout** — Bookmarks now offer Classic, Compact, and Minimal layouts. Minimal keeps rows dense without changing the Path of Exile look.
- **Actions saved per layout** — Choose visible bookmark actions independently for Classic, Compact, and Minimal. Settings and preview update together.

## 1.1.5
### New features
- **Bookmark categories inside folders** — Saved searches can now be grouped into optional categories inside each bookmark folder. The feature is off by default, and turning it off returns every bookmark to the main folder list.
- **Cleaner bookmark action menus** — Category assignment, category creation, and category deletion now live inside the bookmark action menu, with inline creation and the same delete confirmation modal used elsewhere.

### Polish
- **Settings are more compact** — Long setting descriptions now appear as hover help, reducing visual clutter while keeping the details available when you need them.
- **General settings are clearer** — The Interface tab is now General, and Backup & Restore lives there alongside the other extension-wide options.

## 1.1.4
### New features
- **Adjustable text size** — Interface settings now include Small, Medium, Large, and Extra text sizes, with Large as the default.
- **Tutorial access moved to About** — The button to reopen the onboarding tutorial now lives in About, keeping Interface settings focused on display and language options.

## 1.1.3
### New features
- **Full extension backup** — Backup files now include saved folders, searches, global settings, PoE1/PoE2 result settings, and extension preferences in one portable JSON file.
- **Old folder backups still restore** — The restore action still accepts older folder-only .txt exports, so existing backups remain usable.

## 1.1.2
### New features
- **External reference links in the popup** — The popup can now show grouped PoE1 and PoE2 shortcuts for the official trade-adjacent tools, including the Path of Exile Wiki, Path of Exile 2 Wiki, Path of Regex, Craft of Exile, PoEDb, PoE2Db, and poe.ninja.
- **New PoE2 bookmark folder icons** — Disciple of Varashta, Martial Artist, and Spirit Walker icons are available for PoE2 bookmark folders.
- **Mageblood Legacy descriptions for PoE2** — A new Results setting can show hidden Mageblood Legacy effects below PoE2 item results, including duplicate Legacy scaling.

### Fixes
- **Localized PoE2 trade links load correctly** — Bookmarks and helper panels now recognize localized trade2 hosts such as es.pathofexile.com and keep league URLs with spaces encoded correctly.
- **Mageblood Legacy works across languages** — Legacy detection now uses stable trade stat ids, with localized effect descriptions for English, Spanish, Portuguese, Russian, Thai, German, French, Japanese, and Korean.

### Polish
- **Mageblood details stay quiet until hover** — Legacy descriptions show the final value by default, while base value and duplicate effect details appear inline on hover.
- **Mageblood descriptions match item layout** — Legacy description blocks now sit below corrupt/explicit separators like native notable descriptions and stay out of copied item text.

## 1.1.1
### Fixes
- **Foulborn items add the correct modifier** — Quick filter buttons now compensate for mutated Foulborn item rows where the trade site shifts modifier stat ids out of visual order.
- **Bookmark action buttons no longer open searches** — Editing, refreshing, duplicating, or opening the bookmark menu stays inside that action instead of triggering the saved search row.
- **PoE2 copy stays out of PoE1** — The Path of Building copy option is now only shown on the PoE2 trade site.
- **Craft of Exile buttons keep their shape** — The CoE action button is now a centered 30px square so it aligns cleanly with the result row controls.

### Polish
- **Craft of Exile copy avoids unsupported modifier slots** — Items with Prefix/Suffix Modifier allowed affixes now show a greyed CoE button with an explanation, while Copy for PoB keeps working.
- **Version-specific settings are clearer** — PoE1 and PoE2 can keep separate result-tool preferences where that matters, and PoE2-only tools stay hidden on PoE1.

## 1.1.0
### New features
- **Settings are now easier to navigate** — Customization is grouped into Interface, Sidebar, Results, and Bookmarks so each option has a clearer home.
- **Bookmark Layout now has a live preview** — The Bookmarks settings tab shows a real-time saved-search preview using the same action menu as the actual bookmark list.
- **What's New is now built into the sidebar** — New releases can show a compact update prompt, plus a full release notes modal from About.
- **Quick Filter Presets can live where you work** — Enable them from Results settings, then choose whether they appear in the sidebar or directly above the trade site's Stat Filters.
- **Craft of Exile export is easier to reach** — PoE1 and PoE2 result rows can now expose a CoE action that copies items in Craft of Exile's advanced import format.
- **PoE2 copy support for Path of Building** — A dedicated PoE2 copy option can surface beside other result actions and copy item text ready for PoB.
- **Equivalent pricing works across both games** — poe.ninja ratios now support PoE1 and PoE2 so chaos/divine conversion stays useful on either trade site.

### Polish
- **Sidebar and result options were separated** — Visible sidebar modules now live under Sidebar, while injected trade-result tools stay under Results.
- **Add To Filters moved out of the sidebar by default** — Quick filter presets can now be injected into the trade page, keeping the sidebar focused on navigation and saved searches.
- **Bookmark folders remember their open state** — Expanded and collapsed folders persist more predictably across sessions.
- **History labels and trade URLs are cleaner** — League names, fallbacks, and trade-link handling received small consistency improvements.
- **Result cards are easier to use** — Card click handling and seller panel accessibility were tightened for repeated trade workflows.

### Fixes
- **More reliable background messaging** — Background requests and bulk seller caching now handle failure cases more defensively.
- **Finer Filters hover behavior is smoother** — Compact result layouts and item filter buttons now behave more consistently.
- **Bookmark text opens saved searches again** — Clicking the saved-search title now opens the bookmark instead of being ignored.
- **Extension dependencies were hardened** — Dependency overrides and validation changes reduce known package and request risks.
