### PR TITLE
fix: reduce Chrome extension permissions

### DIFF
--- a/Chrome.md
+++ b/Chrome.md
@@ -1,14 +1,14 @@
 🎯 KEY FEATURES:
 
 📌 BOOKMARK MANAGEMENT
-• Organize saved searches into PoE1/PoE2 version-aware folders
-• Create, rename, archive, duplicate, and reorder folders or saved searches instantly
+• Organize saved searches into folders for Path of Exile 1 or Path of Exile 2
+• Create, rename, archive, restore, duplicate, and reorder folders or saved searches instantly
 • Drag and drop folders and bookmarks for fast organization
 • Group saved searches into optional categories inside each folder
 • Choose Classic, Compact, or Minimal bookmark layouts, with actions configured per layout
 • Open one saved search or a whole folder in background tabs with middle-click
 • Saved searches follow the active trade tab's realm and league, with the original league kept as a fallback
-• Browse grouped PoE1 and PoE2 folder icons for currencies, classes, ascendancies, and more
+• Browse grouped Path of Exile 1 and Path of Exile 2 folder icons for currencies, classes, ascendancies, and more
 • Import/export individual folders as portable backup strings
 • Full extension backup and restore for folders, searches, settings, and preferences
 • Restore legacy folder-only .txt backups
@@ -17,21 +17,21 @@
 • Automatically track visited trade searches
 • Return to previous queries with one click
 • Update the active trade tab instead of opening extra windows
-• Keep PoE1 and PoE2 history separate for cleaner navigation
+• Keep Path of Exile 1 and Path of Exile 2 history separate for cleaner navigation
 
 🎨 SMART RESULT ENHANCEMENTS
-• Show live chaos/divine price equivalents from poe.ninja for PoE1 and PoE2
+• Show live chaos/divine price equivalents from poe.ninja for Path of Exile 1 and Path of Exile 2
 • Highlight active stat filters directly in search results
 • Adjust quick filters, including a shortcut to clear Buyout Price
 • Show socket breakpoint warnings for armour items
 • Enable the optional Pinned Items tab to keep results from the current search close at hand and jump back to them with one click
 • Pins are cleared automatically when you start a new search or reload the page, so the list never carries stale results
 • Use integrated Finer Filters for fast stat modifications
-• Open matching PoE Wiki or PoE2 Wiki pages for unique items
-• Show optional Mageblood Legacy descriptions for PoE2 in every supported interface language
-• Copy supported PoE1/PoE2 items in Craft of Exile's advanced import format
+• Open matching Path of Exile Wiki pages for unique items
+• Show optional Mageblood Legacy descriptions for Path of Exile 2 in every supported interface language
+• Copy supported Path of Exile 1 and Path of Exile 2 items in Craft of Exile's advanced import format
 • Optionally include desecrated modifiers in Craft of Exile exports
-• Use the optional PoE2 copy helper for Path of Building workflows
+• Use the optional Path of Exile 2 copy helper for Path of Building workflows
 
 ⚙️ SIDEBAR, POPUP & CUSTOMIZATION
 • Resizable sidebar that adapts the trade-site layout
@@ -40,7 +40,7 @@
 • Choose Small, Medium, Large, or Extra interface text
 • Configure Quick Filter Presets in the sidebar or directly above the trade site's Stat Filters
 • Find setup help and the onboarding tutorial from About
-• Open grouped popup shortcuts for Wiki, PoE2 Wiki, Path of Regex, Craft of Exile, PoEDb, PoE2Db, and poe.ninja
+• Open grouped popup shortcuts for the wikis, Path of Regex, Craft of Exile, PoEDb, PoE2Db, and poe.ninja
 
 🔄 BROWSER SYNC & STORAGE
 • Sync bookmarks, bookmark folders, and extension settings between installations signed into the same browser profile
@@ -50,13 +50,15 @@
 
 🌍 SUPPORTED TRADE SITES & LANGUAGES
 • Global: pathofexile.com
-• Localized trade sites: BR, RU, TH, DE, FR, ES, and JP
+• Localized trade sites: Brazil, Russia, Thailand, Germany, France, Spain, and Japan
 • Taiwan: pathofexile.tw
 • Kakao Games: poe.kakaogames.com and poe2.kakaogames.com
 • Interface languages: English, Portuguese, Russian, Thai, German, French, Spanish, Japanese, Korean, Traditional Chinese, and Simplified Chinese
+• Chinese Trade translation supports the international Path of Exile 1 trade site and Taiwan server, using bundled local dictionaries
 
 💿 DATA PRIVACY
 ✓ No PoeTradePlus account, tracking, analytics, or application-owned data server
 ✓ Saved-search data stays in browser storage; when browser Sync is enabled, bookmarks and settings use the browser's built-in Sync service
-✓ Only reads poe.ninja for price ratios; external reference sites open only when you choose them
+✓ Reads poe.ninja for optional price ratios; when Chinese Trade translation is enabled, it also retrieves official Path of Exile Trade metadata needed for that feature
+✓ External reference sites open only when you choose them
 ✓ Full source code available on GitHub

--- a/README.md
+++ b/README.md
@@ -19,60 +19,74 @@ The project currently focuses on making recurring trade searches easier to save,
 
 ## Features
 
-### Sidebar workflow
+### 📌 Bookmark management
 
-- **Integrated trade sidebar:** Poe Trade Plus mounts directly inside official Path of Exile trade pages, including PoE1, PoE2, and localized trade hosts.
-- **Resizable layout:** the sidebar width can be adjusted and persisted locally.
-- **Minimize and restore mode:** collapse the panel into a floating pill to recover screen space.
-- **Left or right docking:** choose which side of the trade site the panel should live on.
-- **Trade-site-aware layout shift:** the page adapts to the sidebar width so the official site remains usable.
-- **Popup shortcuts:** optional grouped links for Path of Exile Wiki, Path of Exile 2 Wiki, Path of Regex, Craft of Exile, PoEDb, PoE2Db, and poe.ninja.
+- Organize saved searches into folders aware of the active Path of Exile trade version.
+- Create, rename, archive, restore, duplicate, and reorder folders or saved searches instantly.
+- Drag and drop folders and bookmarks for fast organization.
+- Group saved searches into optional categories inside each folder.
+- Choose Classic, Compact, or Minimal bookmark layouts, with actions configured per layout.
+- Open one saved search or a whole folder in background tabs with middle-click.
+- Saved searches follow the active trade tab's realm and league, with the original league kept as a fallback.
+- Browse grouped Path of Exile 1 and 2 folder icons for currencies, classes, ascendancies, and more.
+- Import and export individual folders as portable backup strings.
+- Create a full extension backup for folders, searches, settings, and preferences, then restore it elsewhere.
+- Restore legacy folder-only `.txt` backups.
 
-### Bookmarks and folders
+### ⏱️ Search history
 
-- **Version-aware folders:** bookmarks are separated by Path of Exile trade version.
-- **Folder creation and inline organization:** create, rename, expand, collapse, archive, and delete folders in place.
-- **Drag and drop reordering:** reorder folders and searches without leaving the panel.
-- **Per-folder import:** paste a serialized folder string and restore it instantly.
-- **Full backup and restore:** export a portable `.json` file with folders, saved searches, settings, and extension preferences, then restore it in another browser.
-- **Legacy backup support:** older folder-only `.txt` backups can still be restored.
-- **Archived view:** switch between active and archived folders without losing saved searches.
-- **PoE2 folder icons:** includes PoE2 currency, class, ascendancy, and themed folder icons.
+- Automatically track visited trade searches.
+- Return to previous queries with one click.
+- Update the active trade tab instead of opening extra windows.
+- Keep Path of Exile 1 and 2 history separate for cleaner navigation.
 
-### Search history and navigation
+### 🎨 Smart result enhancements
 
-- **Automatic trade history:** visited searches are tracked and stored locally.
-- **Active-tab integration:** reopening a saved history entry updates the current trade tab instead of spawning extra tabs.
-- **Version filtering:** history entries are filtered to the currently detected trade version.
+- Show live chaos/divine price equivalents from `poe.ninja` for Path of Exile 1 and 2.
+- Highlight active stat filters directly in search results.
+- Adjust quick filters, including a shortcut to clear Buyout Price.
+- Show socket breakpoint warnings for armour items.
+- Enable the optional Pinned Items tab to keep results from the current search close at hand and jump back to them with one click.
+- Clear pins automatically when a new search starts or the page reloads, so the list never carries stale results.
+- Use integrated Finer Filters for fast stat modifications.
+- Open matching Path of Exile 1 and 2 Wiki pages for unique items.
+- Show optional Mageblood Legacy descriptions for Path of Exile 2 in supported interface languages.
+- Copy supported Path of Exile 1 and 2 items in Craft of Exile's advanced import format.
+- Optionally include desecrated modifiers in Craft of Exile exports.
+- Use the optional Path of Exile 2 copy helper for Path of Building workflows.
 
-### Result enhancements
+### ⚙️ Sidebar, popup, and customization
 
-- **Equivalent pricing:** optionally show chaos and divine equivalents using live `poe.ninja` currency ratios.
-- **Search-stat highlighting:** active stat filters are highlighted in the result list.
-- **Socket breakpoint warnings:** armor results can display max-socket warnings based on item level.
-- **Scroll back to result:** pinned-result navigation can scroll the active result list to a specific item.
-- **Mageblood Legacy descriptions:** optionally show hidden PoE2 Mageblood Legacy effects below item results, including duplicate Legacy scaling.
-- **Localized Mageblood support:** Mageblood Legacy detection uses stable trade stat ids and localized descriptions for English, Spanish, Portuguese, Russian, Thai, German, French, Japanese, and Korean.
-- **Craft of Exile export:** copy supported PoE1 and PoE2 item results in Craft of Exile's advanced import format.
-- **PoE2 copy helper:** optionally expose PoE2's native copy action for Path of Building workflows.
+- Use a resizable sidebar that adapts the trade-site layout.
+- Dock the panel on the left or right, or minimize it to a floating pill.
+- Persist sidebar width, position, text size, language, and result-tool preferences.
+- Choose Small, Medium, Large, or Extra interface text.
+- Configure Quick Filter Presets in the sidebar or directly above the trade site's Stat Filters.
+- Find setup help and the onboarding tutorial from About.
+- Open grouped popup shortcuts for popular Path of Exile tools and reference sites.
 
-### Filter helpers
+### 🔄 Browser Sync and storage
 
-- **Finer Filters integration:** add or exclude modifiers directly from hovered result stats.
-- **Grouped quick actions:** includes pseudo and explicit presets such as resistance/life, attack weapon, and spell weapon filters.
-- **Regex-friendly search inputs:** native trade-site search inputs automatically get the `~` prefix when appropriate.
+- Sync bookmarks, bookmark folders, and extension settings between installations signed into the same browser profile.
+- Safely migrate existing bookmark and settings data when updating.
+- Compact and chunk synced data to stay within browser Sync storage limits.
+- Keep search history and other high-volume data local to the browser.
 
-### Settings and local persistence
+### 🌍 Supported trade sites and languages
 
-- **Sidebar position preference**
-- **Equivalent pricing visibility toggle**
-- **PoE1 and PoE2 result settings**
-- **Mageblood Legacy description toggle**
-- **History, bulk sellers, quick filters, Craft of Exile, and PoE2 copy toggles**
-- **Persistent sidebar width**
-- **Local browser storage for settings, folders, history, and extension preferences**
-- **Portable full-extension backup file for moving data between browsers**
-- **Ephemeral caching for `poe.ninja` currency ratios**
+- Global: `pathofexile.com`.
+- Localized trade sites: BR, RU, TH, DE, FR, ES, JP, and Taiwan.
+- Kakao Games: `poe.kakaogames.com` and `poe2.kakaogames.com`.
+- Interface languages: English, Portuguese, Russian, Thai, German, French, Spanish, Japanese, Korean, Simplified Chinese, and Traditional Chinese.
+- Chinese Trade translation supports the international PoE1 trade site and Taiwan server, using bundled local dictionaries.
+
+### 💿 Data privacy
+
+- No Poe Trade Plus account, tracking, analytics, or application-owned data server.
+- Saved-search data stays in browser storage; when browser Sync is enabled, bookmarks and settings use the browser's built-in Sync service.
+- `poe.ninja` is read for optional price ratios. When Chinese Trade translation is enabled, the extension also retrieves official Path of Exile Trade metadata needed for that feature.
+- External reference sites open only when you choose them.
+- Full source code is available on GitHub.
 
 ## Tech Stack
 
@@ -107,18 +121,18 @@ See `docs/ARCHITECTURE.md` for a deeper architectural overview, `docs/EXTENSION-
 ### Requirements
 
 - Node.js
-- npm
+- pnpm
 
 ### Install dependencies
 
 ```bash
-npm install
+pnpm install
 ```
 
 ### Run development build
 
 ```bash
-npm run dev
+pnpm dev
 ```
 
 Load the generated development output from `build/chrome-mv3` in your browser's extensions page.
@@ -126,17 +140,15 @@ Load the generated development output from `build/chrome-mv3` in your browser's 
 ### Production build
 
 ```bash
-npm run build
+pnpm build
 ```
 
-This build step also runs the local version bump script before generating the final extension bundle.
-
-The unpacked production extension is generated in `build/chrome-mv3`.
+The unpacked production extensions are generated in `build/chrome-mv3` and `build/firefox-mv2`.
 
 ### Package the extension
 
 ```bash
-npm run package
+pnpm package
 ```
 
 This command creates browser-specific zip files in `build/`, such as `poe-trade-plus-1.0.70-chrome.zip` and `poe-trade-plus-1.0.70-firefox.zip`.
@@ -158,7 +170,7 @@ docs(readme): document release notes workflow
 To update the in-app release notes from Git commits, run:
 
 ```bash
-npm run whats-new
+pnpm whats-new
 ```
 
 The script reads commits since the latest `v*` tag, groups `feat:` commits as new features, `fix:` and `perf:` commits as fixes, and keeps `docs:`, `chore:`, and `build:` entries out of the user-facing What's New unless they affect users directly. It also has a fallback for existing non-conventional subjects such as `Add ...`, `Show ...`, and `Refine ...`.
@@ -173,7 +185,7 @@ The script reads commits since the latest `v*` tag, groups `feat:` commits as ne
 
 ## Credits
 
-This project is based on or incorporates ideas/material from:
+This project incorporates ideas or material from:
 
 - [better-trading](https://github.com/exile-center/better-trading)
 - [poe-trade-plus](https://github.com/KroxiLabs/poe-trade-plus/)
@@ -182,7 +194,7 @@ Special Thanks: Trompetin17, Maxime B and Fuzzy for creating the original script
 
 ## Privacy policy
 
-We do not save nor require any data from the end user, if this extension ever uses data from a user will be saved LOCALLY and we won't have any way whatsoever to access it.
+Poe Trade Plus has no account system, analytics, tracking, or application-owned data server. Saved searches, folders, settings, and preferences stay in browser storage. If browser Sync is enabled, supported bookmarks and settings use the browser's built-in Sync service; search history and other high-volume data remain local. The extension requests `poe.ninja` only for optional price ratios and official Path of Exile Trade endpoints only when needed by enabled trade features such as Chinese Trade translation.
 
 ## License
 

--- a/components/pages/Settings.svelte
+++ b/components/pages/Settings.svelte
@@ -307,14 +307,9 @@
     const source = language === "zh-cn"
       ? chineseTradeStorage.simplified
       : chineseTradeStorage.traditional;
-    const sourceKeys = [source.stats, source.staticData, source.filters, source.items];
+    const sourceKeys = [source.stats];
     const cache = await readChineseTradeCache(sourceKeys);
-    const targets: Record<string, string> = {
-      stats: "lscache-tradestats",
-      static: "lscache-tradedata",
-      filters: "lscache-tradefilters",
-      items: "lscache-tradeitems"
-    };
+    const targets: Record<string, string> = { stats: "lscache-tradestats" };
 
     let injected = false;
     for (const [[, target], sourceKey] of Object.entries(targets).map(

--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -1,13 +1,8 @@
 import { registerBackgroundHandlers } from "~/lib/background"
 import { buildChineseItemNameCache } from "~/lib/services/chinese-trade/item-name-cache"
 import { refreshChineseTradeCache } from "~/lib/services/chinese-trade/cache-builder"
-import {
-  getChineseTradeLanguage,
-  getTradeTranslationState
-} from "~/lib/services/trade-translation"
+import { getTradeTranslationState } from "~/lib/services/trade-translation"
 import { chineseTradeMessage } from "~/lib/services/chinese-trade/contract"
-
-const SUPPLEMENT_FILE = "content-scripts/chinese-trade-supplement.js"
 
 const prepareChineseTradeCaches = async (force = false) => {
   if (!force && !(await getTradeTranslationState()).enabled) return
@@ -44,22 +39,6 @@ const isTaiwanPoe1Trade = (url: string | undefined) => {
   }
 }
 
-const injectChineseSupplement = async (tabId: number, url?: string) => {
-  const nativeTaiwan = isTaiwanPoe1Trade(url)
-  if (!nativeTaiwan && !isInternationalPoe1Trade(url)) return
-  if (!(await getChineseTradeLanguage())) return
-  const state = await getTradeTranslationState()
-  if (!nativeTaiwan && !state.enabled) return
-  try {
-    await chrome.scripting.executeScript({
-      target: { tabId },
-      files: [SUPPLEMENT_FILE]
-    })
-  } catch {
-    // The tab may have navigated away while the settings read was pending.
-  }
-}
-
 const reloadPoe1TradeTabs = async () => {
   const tabs = await chrome.tabs.query({})
   await Promise.all(
@@ -86,11 +65,6 @@ export default defineBackground({
   main() {
     registerBackgroundHandlers()
     void prepareChineseTradeCaches()
-    chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
-      if (changeInfo.status === "loading") {
-        void injectChineseSupplement(tabId, tab.url)
-      }
-    })
     chrome.runtime.onInstalled.addListener(() => {
       void prepareChineseTradeCaches()
     })

--- a/entrypoints/chinese-trade-cache.content.ts
+++ b/entrypoints/chinese-trade-cache.content.ts
@@ -61,10 +61,7 @@ export default defineContentScript({
       ? chineseTradeStorage.simplified
       : chineseTradeStorage.traditional
     const targets: Array<[string, (typeof tradeCacheKeys)[number]]> = [
-      [locale.stats, "lscache-tradestats"],
-      [locale.staticData, "lscache-tradedata"],
-      [locale.filters, "lscache-tradefilters"],
-      [locale.items, "lscache-tradeitems"]
+      [locale.stats, "lscache-tradestats"]
     ]
 
     let values: Record<string, unknown>

--- a/entrypoints/chinese-trade-results.content.ts
+++ b/entrypoints/chinese-trade-results.content.ts
@@ -5,9 +5,16 @@ import {
   normalizeEnglishTradeText,
   resolveTradeDisplayText
 } from "~/lib/services/chinese-trade/text-transform"
+import type { ChineseStatTemplates } from "~/lib/services/chinese-trade/stat-cache-transform"
 import { getTradeTranslationState } from "~/lib/services/trade-translation"
 
 type Modifier = { tw: string; us?: string; opt?: Record<string, string> }
+
+let bundledTemplatesPromise: Promise<ChineseStatTemplates> | undefined
+const loadBundledTemplates = () =>
+  (bundledTemplatesPromise ??= import("~/data/chinese-trade/stat-templates.json").then(
+    ({ default: templates }) => templates as ChineseStatTemplates
+  ))
 
 const isChinese = (value: string) => /[一-鿿]/.test(value)
 const numberTokens = /[+-]?\d+(?:\.\d+)?/g
@@ -56,6 +63,15 @@ export default defineContentScript({
     let templates: Record<string, string> = {}
     let modifiers: Record<string, Modifier> = {}
 
+    try {
+      const bundledTemplates = await loadBundledTemplates()
+      templates = state.language === "zh-cn"
+        ? bundledTemplates.cn ?? {}
+        : bundledTemplates.tw ?? {}
+    } catch {
+      // Result modifiers still use the smaller stat-id cache as a fallback.
+    }
+
     const translate = (element: HTMLElement) => {
       const content =
         element.querySelector<HTMLElement>("[data-field]") ??
@@ -79,11 +95,7 @@ export default defineContentScript({
     }
 
     const applyCache = (data: Record<string, unknown>) => {
-      const nextTemplates = data[locale.templates]
       const nextModifiers = data[locale.modifiers]
-      if (nextTemplates && typeof nextTemplates === "object") {
-        templates = nextTemplates as Record<string, string>
-      }
       if (nextModifiers && typeof nextModifiers === "object") {
         modifiers = nextModifiers as Record<string, Modifier>
       }
@@ -91,13 +103,13 @@ export default defineContentScript({
     }
 
     try {
-      chrome.storage.local.get([locale.templates, locale.modifiers], (data) =>
+      chrome.storage.local.get([locale.modifiers], (data) =>
         applyCache(data as Record<string, unknown>)
       )
       chrome.storage.onChanged.addListener((changes, area) => {
         if (area !== "local") return
         const changed: Record<string, unknown> = {}
-        for (const key of [locale.templates, locale.modifiers]) {
+        for (const key of [locale.modifiers]) {
           if (changes[key]) changed[key] = changes[key].newValue
         }
         if (Object.keys(changed).length) applyCache(changed)

--- a/entrypoints/chinese-trade-supplement.content.ts
+++ b/entrypoints/chinese-trade-supplement.content.ts
@@ -24,7 +24,11 @@ type ModifierMap = Record<string, { us?: string; tw?: string }>
 
 export default defineContentScript({
   matches: tradeHosts,
-  excludeMatches: ["*://*/*"],
+  excludeMatches: [
+    "*://*/trade2/*",
+    "https://poe.kakaogames.com/*",
+    "https://poe2.kakaogames.com/*"
+  ],
   runAt: "document_idle",
 
   async main() {

--- a/lib/services/chinese-trade/cache-builder.ts
+++ b/lib/services/chinese-trade/cache-builder.ts
@@ -37,6 +37,27 @@ const writeCache = (payload: Record<string, unknown>): Promise<void> =>
     })
   )
 
+const removeSupersededCache = (): Promise<void> =>
+  new Promise((resolve, reject) =>
+    chrome.storage.local.remove(
+      [
+        "poeTradePlus.chineseTrade.traditional.static",
+        "poeTradePlus.chineseTrade.simplified.static",
+        "poeTradePlus.chineseTrade.traditional.filters",
+        "poeTradePlus.chineseTrade.simplified.filters",
+        "poeTradePlus.chineseTrade.traditional.items",
+        "poeTradePlus.chineseTrade.simplified.items",
+        "poeTradePlus.chineseTrade.traditional.templates",
+        "poeTradePlus.chineseTrade.simplified.templates"
+      ],
+      () => {
+        const error = chrome.runtime.lastError
+        if (error) reject(new Error(error.message))
+        else resolve()
+      }
+    )
+  )
+
 const fetchTradeResult = async (url: string): Promise<TradeStatGroup[] | null> => {
   const response = await fetch(url, { credentials: "omit" })
   if (!response.ok) throw new Error(`${url} -> ${response.status}`)
@@ -111,26 +132,13 @@ export const refreshChineseTradeCache = async (force = false): Promise<void> => 
         taiwanStats,
         internationalStats
       ),
-      [chineseTradeStorage.traditional.templates]: templates.tw ?? {},
-      [chineseTradeStorage.simplified.templates]: templates.cn ?? {}
-    }
-
-    const [traditionalStatic, traditionalFilters] = await Promise.all([
-      fetchTradeResult(`${TAIWAN_TRADE_API}static`).catch(() => null),
-      fetchTradeResult(`${TAIWAN_TRADE_API}filters`).catch(() => null)
-    ])
-    if (traditionalStatic) {
-      payload[chineseTradeStorage.traditional.staticData] = traditionalStatic
-      payload[chineseTradeStorage.simplified.staticData] = convertDeep(traditionalStatic)
-    }
-    if (traditionalFilters) {
-      payload[chineseTradeStorage.traditional.filters] = traditionalFilters
-      payload[chineseTradeStorage.simplified.filters] = convertDeep(traditionalFilters)
+      [chineseTradeStorage.simplified.modifiers]: {}
     }
     payload[chineseTradeStorage.simplified.modifiers] = convertDeep(
       payload[chineseTradeStorage.traditional.modifiers]
     )
 
+    await removeSupersededCache()
     await writeCache(payload)
   } catch (error) {
     console.error("[PoeTradePlus] Failed to refresh the Chinese Trade cache", error)

--- a/lib/services/chinese-trade/contract.ts
+++ b/lib/services/chinese-trade/contract.ts
@@ -9,21 +9,13 @@ export const chineseTradeStorage = {
   itemNamesUpdatedAt: "poeTradePlus.chineseTrade.itemNamesUpdatedAt",
   traditional: {
     stats: "poeTradePlus.chineseTrade.traditional.stats",
-    staticData: "poeTradePlus.chineseTrade.traditional.static",
-    filters: "poeTradePlus.chineseTrade.traditional.filters",
-    items: "poeTradePlus.chineseTrade.traditional.items",
     modifiers: "poeTradePlus.chineseTrade.traditional.modifiers",
-    templates: "poeTradePlus.chineseTrade.traditional.templates",
     itemNames: "poeTradePlus.chineseTrade.traditional.itemNames",
     reverseNames: "poeTradePlus.chineseTrade.traditional.reverseNames"
   },
   simplified: {
     stats: "poeTradePlus.chineseTrade.simplified.stats",
-    staticData: "poeTradePlus.chineseTrade.simplified.static",
-    filters: "poeTradePlus.chineseTrade.simplified.filters",
-    items: "poeTradePlus.chineseTrade.simplified.items",
     modifiers: "poeTradePlus.chineseTrade.simplified.modifiers",
-    templates: "poeTradePlus.chineseTrade.simplified.templates",
     itemNames: "poeTradePlus.chineseTrade.simplified.itemNames",
     reverseNames: "poeTradePlus.chineseTrade.simplified.reverseNames"
   }

--- a/lib/services/chinese-trade/item-name-cache.ts
+++ b/lib/services/chinese-trade/item-name-cache.ts
@@ -259,8 +259,6 @@ export const buildChineseItemNameCache = async (force = false): Promise<void> =>
       [timestampKey]: Date.now(),
       [chineseTradeStorage.traditional.itemNames]: traditionalMap,
       [chineseTradeStorage.simplified.itemNames]: simplifiedMap,
-      [chineseTradeStorage.traditional.items]: traditional.result,
-      [chineseTradeStorage.simplified.items]: simplified.result,
       [chineseTradeStorage.traditional.reverseNames]: traditional.reverse,
       [chineseTradeStorage.simplified.reverseNames]: simplified.reverse
     })

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "poe-trade-plus",
   "displayName": "Poe Trade Plus",
-  "version": "1.1.20",
+  "version": "1.1.21",
   "packageManager": "pnpm@11.3.0",
   "license": "MIT",
   "description": "Poe Trade Plus enhances the Path of Exile trade site with bookmarks, history and result tools.",

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -38,7 +38,7 @@ export default defineConfig({
     name: "Poe Trade Plus",
     description:
       "Poe Trade Plus enhances the Path of Exile trade site with bookmarks, history and result tools.",
-    permissions: ["storage", "tabs", "scripting", "unlimitedStorage"],
+    permissions: ["storage", "tabs"],
     host_permissions: [
       ...tradeHostPermissions,
       "https://pathofexile.com/*",


### PR DESCRIPTION
## What changed
- Removes the `unlimitedStorage` and `scripting` permissions from the Chrome manifest.
- Keeps Chinese Trade storage below Chrome's default local quota by persisting only the required translated indexes.
- Replaces dynamic script injection with a declarative, Path of Exile 1-only content script.
- Updates Chrome Web Store copy, README feature documentation, and the version to 1.1.21.

## Why
Chrome Web Store required justifications for permissions that are no longer necessary. The slimmer cache preserves the translation workflow without requesting elevated permissions.

## Validation
- `pnpm typecheck`
- `pnpm test`
- `pnpm build:chrome`
- Verified the generated manifest declares only `storage` and `tabs`.