### PR TITLE
fix(bookmarks): stop scroll restore from overriding the wheel

### DIFF
--- a/components/pages/Bookmarks.svelte
+++ b/components/pages/Bookmarks.svelte
@@ -13,6 +13,7 @@
     clearBookmarkScroll,
     consumeBookmarkScroll
   } from "../../lib/services/bookmark-scroll";
+  import { decideScrollRestore } from "../../lib/services/bookmark-scroll-restore";
   import { tradeLocationService } from "../../lib/services/trade-location";
   import { flashMessages } from "../../lib/services/flash";
   import { storageService } from "../../lib/services/storage";
@@ -332,19 +333,6 @@
     isAtBookmarkTop = !scrollContainer || scrollContainer.scrollTop <= 0;
   };
 
-  const restoreBookmarkScroll = async () => {
-    if (!scrollContainer) return true;
-
-    const top = await consumeBookmarkScroll();
-    if (top === null) return true;
-
-    scrollContainer.scrollTop = top;
-    syncBookmarkTop();
-    const canReachSavedPosition =
-      scrollContainer.scrollHeight - scrollContainer.clientHeight >= top;
-    if (canReachSavedPosition) await clearBookmarkScroll();
-    return canReachSavedPosition;
-  };
 
   const clearToolbarRepairTimers = () => {
     if (toolbarRepairFrame) {
@@ -467,26 +455,79 @@
   $effect(() => {
     if (!scrollContainer) return;
 
-    const observer = new ResizeObserver(() => void restoreBookmarkScroll());
-    observer.observe(scrollContainer);
-    const restoreTimer = window.setInterval(() => {
-      void restoreBookmarkScroll().then((restored) => {
-        if (restored) window.clearInterval(restoreTimer);
-      });
-    }, 80);
-    const restoreTimeout = window.setTimeout(() => {
-      window.clearInterval(restoreTimer);
-      void clearBookmarkScroll();
-      observer.disconnect();
-    }, 3000);
+    const el = scrollContainer;
+    // Taking over must cancel the restore, or the retry ticks fight the wheel.
+    const userInputEvents = ["wheel", "touchstart", "pointerdown", "keydown"] as const;
 
-    void tick().then(() => restoreBookmarkScroll());
+    let savedTop: number | null = null;
+    let hasConsumed = false;
+    let userInteracted = false;
+    let stopped = false;
+    let restoreTimer = 0;
+    let restoreTimeout = 0;
 
-    return () => {
+    function onUserInput() {
+      userInteracted = true;
+      stop(true);
+    }
+
+    function stop(clearStored: boolean) {
+      if (stopped) return;
+      stopped = true;
       window.clearInterval(restoreTimer);
       window.clearTimeout(restoreTimeout);
       observer.disconnect();
+      for (const type of userInputEvents) {
+        el.removeEventListener(type, onUserInput);
+      }
+      if (clearStored) void clearBookmarkScroll();
+    }
+
+    const runRestore = async () => {
+      if (stopped) return;
+
+      // Read once per cycle; retries reuse the cached offset.
+      if (!hasConsumed) {
+        hasConsumed = true;
+        savedTop = await consumeBookmarkScroll();
+      }
+      // A gesture can land while the read is in flight.
+      if (stopped || userInteracted) return;
+
+      const outcome = decideScrollRestore({
+        savedTop,
+        scrollHeight: el.scrollHeight,
+        clientHeight: el.clientHeight,
+        userInteracted
+      });
+
+      if (outcome === "abort") {
+        stop(true);
+        return;
+      }
+      if (outcome === "idle" || savedTop === null) {
+        stop(false);
+        return;
+      }
+
+      el.scrollTop = savedTop;
+      syncBookmarkTop();
+      if (outcome === "settle") stop(true);
     };
+
+    const observer = new ResizeObserver(() => void runRestore());
+
+    for (const type of userInputEvents) {
+      el.addEventListener(type, onUserInput, { passive: true, once: true });
+    }
+
+    observer.observe(el);
+    restoreTimer = window.setInterval(() => void runRestore(), 80);
+    restoreTimeout = window.setTimeout(() => stop(true), 3000);
+
+    void tick().then(() => runRestore());
+
+    return () => stop(false);
   });
 
   $effect(() => {

--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -363,6 +363,8 @@ export default defineBackground({
               sendResponse({ top: null })
               return
             }
+            // Read-once: the caller caches the offset and retries locally.
+            await storageService.deleteValue(bookmarkScrollKey)
             sendResponse({ top: saved.top })
           })
           .catch(() => sendResponse({ top: null }))

--- a/lib/services/bookmark-scroll-restore.ts
+++ b/lib/services/bookmark-scroll-restore.ts
@@ -1,0 +1,27 @@
+export type ScrollRestoreOutcome = "abort" | "idle" | "settle" | "retry"
+
+export type ScrollRestoreInput = {
+  savedTop: number | null
+  scrollHeight: number
+  clientHeight: number
+  userInteracted: boolean
+}
+
+/**
+ * Picks the action for one scroll-restore tick.
+ *
+ * `retry` covers rows still loading; `abort` outranks it so a restore never
+ * fights the wheel while the saved offset stays out of reach.
+ */
+export const decideScrollRestore = ({
+  savedTop,
+  scrollHeight,
+  clientHeight,
+  userInteracted
+}: ScrollRestoreInput): ScrollRestoreOutcome => {
+  if (userInteracted) return "abort"
+  if (savedTop === null || !Number.isFinite(savedTop) || savedTop < 0) return "idle"
+
+  const maxTop = Math.max(0, scrollHeight - clientHeight)
+  return maxTop >= savedTop ? "settle" : "retry"
+}

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "whats-new": "node scripts/generate-whats-new.cjs",
     "data:refresh": "node scripts/refresh-trade-locale-data.mjs && node scripts/refresh-chinese-trade-dictionaries.mjs",
     "trade:fixtures:update": "node scripts/trade-fixtures-update.mjs",
-    "test": "pnpm run test:bookmark-sync && node --no-warnings --experimental-strip-types --test tests/bookmark-export-compatibility.test.mjs tests/legacy-bookmark-search-state.test.mjs tests/chinese-trade-text-transform.test.mjs tests/chinese-trade-stat-cache.test.mjs tests/chinese-trade-cache-lifecycle.test.mjs tests/normalize-valdo-reward-name.test.mjs tests/trade-selectors.test.mjs tests/trade-filters.test.mjs tests/trade-dom.test.mjs tests/trade-context.test.mjs tests/feature-lifecycle.test.mjs tests/trade-dom-observer.test.mjs tests/extension-bus.test.mjs",
+    "test": "pnpm run test:bookmark-sync && node --no-warnings --experimental-strip-types --test tests/bookmark-export-compatibility.test.mjs tests/legacy-bookmark-search-state.test.mjs tests/bookmark-scroll-restore.test.mjs tests/chinese-trade-text-transform.test.mjs tests/chinese-trade-stat-cache.test.mjs tests/chinese-trade-cache-lifecycle.test.mjs tests/normalize-valdo-reward-name.test.mjs tests/trade-selectors.test.mjs tests/trade-filters.test.mjs tests/trade-dom.test.mjs tests/trade-context.test.mjs tests/feature-lifecycle.test.mjs tests/trade-dom-observer.test.mjs tests/extension-bus.test.mjs",
     "test:bookmark-sync": "node scripts/test-bookmark-sync.cjs",
     "test:bookmark-exports": "pnpm test",
     "typecheck": "tsc --noEmit",

--- a/tests/bookmark-scroll-restore.test.mjs
+++ b/tests/bookmark-scroll-restore.test.mjs
@@ -1,0 +1,70 @@
+// The bookmark list stores its scroll offset when a saved search is opened and
+// restores it after the trade page navigates. Retries are needed because rows
+// load asynchronously, but a retry that outlives the user's wheel made the list
+// unscrollable whenever the content stayed shorter than the saved offset.
+
+import assert from "node:assert/strict"
+import test from "node:test"
+
+const { decideScrollRestore } = await import("../lib/services/bookmark-scroll-restore.ts")
+
+const base = {
+  savedTop: 400,
+  scrollHeight: 2000,
+  clientHeight: 800,
+  userInteracted: false
+}
+
+test("aborts as soon as the user scrolls, even while the offset is unreachable", () => {
+  // Arrange: offset out of reach, so the loop is mid-retry.
+  const input = { ...base, scrollHeight: 500, clientHeight: 800, userInteracted: true }
+
+  // Act
+  const outcome = decideScrollRestore(input)
+
+  // Assert: the user wins. This stayed "retry" before the fix.
+  assert.equal(outcome, "abort")
+})
+
+test("aborts on user input even when the offset is reachable", () => {
+  assert.equal(decideScrollRestore({ ...base, userInteracted: true }), "abort")
+})
+
+test("settles once the saved offset is reachable", () => {
+  assert.equal(decideScrollRestore(base), "settle")
+})
+
+test("settles on the exact boundary where the offset just fits", () => {
+  const input = { ...base, savedTop: 1200, scrollHeight: 2000, clientHeight: 800 }
+  assert.equal(decideScrollRestore(input), "settle")
+})
+
+test("retries while the content is still shorter than the saved offset", () => {
+  // Reported trigger: expanding another folder grows scrollHeight and settles.
+  const short = { ...base, savedTop: 1201, scrollHeight: 2000, clientHeight: 800 }
+  assert.equal(decideScrollRestore(short), "retry")
+
+  const grown = { ...short, scrollHeight: 2400 }
+  assert.equal(decideScrollRestore(grown), "settle")
+})
+
+test("is idle when nothing was stored", () => {
+  assert.equal(decideScrollRestore({ ...base, savedTop: null }), "idle")
+})
+
+test("is idle for a non-finite or negative offset", () => {
+  assert.equal(decideScrollRestore({ ...base, savedTop: Number.NaN }), "idle")
+  assert.equal(decideScrollRestore({ ...base, savedTop: Number.POSITIVE_INFINITY }), "idle")
+  assert.equal(decideScrollRestore({ ...base, savedTop: -1 }), "idle")
+})
+
+test("treats a container with no overflow as reachable at offset 0", () => {
+  const input = { ...base, savedTop: 0, scrollHeight: 600, clientHeight: 800 }
+  assert.equal(decideScrollRestore(input), "settle")
+})
+
+test("never reports a negative reachable range", () => {
+  // maxTop must clamp at 0 rather than go negative.
+  const input = { ...base, savedTop: 1, scrollHeight: 100, clientHeight: 900 }
+  assert.equal(decideScrollRestore(input), "retry")
+})


### PR DESCRIPTION
## Problem

The bookmark list could not be scrolled by hand. Turning the wheel snapped the
list straight back, so the controls on the lower saved-search rows were
unreachable.

Opening a saved search stores the sidebar scroll offset so the position
survives the trade-page navigation. On remount the restore retries every 80ms,
because a folder's rows load asynchronously, and settles only once
`scrollHeight - clientHeight >= savedTop`.

While the saved offset stayed out of reach that condition never held, so the
loop kept re-applying the offset on every tick and overrode the wheel about 12
times a second. Expanding a second folder grew the content past the saved
offset, the loop settled, and scrolling worked again — which is how the report
reproduced it.

Two things kept it alive:

- `restoreBookmarkScroll` had no notion of user input, so programmatic scroll
  always won.
- The background `consume` handler deleted the stored offset only when it was
  stale, so every later remount within its 30s lifetime re-armed the same loop.

## Change

- `Bookmarks.svelte` reads the stored offset once per cycle and retries against
  the cached value instead of re-reading storage on every tick.
- The restore now cancels on the first `wheel`, `touchstart`, `pointerdown`, or
  `keydown` on the container, and clears the stored offset when it does.
- The background `consume` handler deletes on read, which matches the
  fire-once contract its callers already documented.
- The decision moved into `decideScrollRestore` in
  `lib/services/bookmark-scroll-restore.ts`, kept free of `chrome.*` so it is
  directly testable.

Restoring scroll after navigation still works: `retry` still covers rows that
have not landed yet, it is still bounded by the existing 3s timeout, and a user
gesture now outranks it.

## Testing

- `pnpm typecheck` — clean
- `pnpm test` — 82 passing (73 before, 9 new)
- `pnpm build` — Chrome and Firefox

`tests/bookmark-scroll-restore.test.mjs` covers the reported trigger: a short
container returns `retry`, and growing `scrollHeight` settles it. Against the
previous logic 4 of the 9 cases fail, including the one asserting that a user
gesture aborts a restore whose offset is out of reach.

No user-facing strings were added, so no locale files changed. I left the
What's New entry and the version bump to your release flow rather than guessing
the next version.
