### PR TITLE
fix(bookmarks): show save progress and drop the duplicate draft row

### DIFF
--- a/components/BookmarkFolder.svelte
+++ b/components/BookmarkFolder.svelte
@@ -27,6 +27,7 @@
     consumeBookmarkScroll,
     saveBookmarkScroll
   } from "../lib/services/bookmark-scroll"
+  import { decideTradeSync } from "../lib/services/bookmark-trade-sync"
   import { bookmarksService } from "../lib/services/bookmarks"
   import {
     bookmarkFolderIconOptions,
@@ -204,15 +205,16 @@
   }
 
   const unsubscribeBookmarksChange = bookmarksService.onChange((event) => {
-    if (!folder.id || !event?.tradesChanged || event.folderId !== folder.id) {
-      return
-    }
+    const outcome = decideTradeSync({
+      folderId: folder.id,
+      eventFolderId: event?.folderId,
+      tradesChanged: !!event?.tradesChanged,
+      isExpanded,
+      isCommittingDraft
+    })
 
-    if (isExpanded) {
-      syncTradesFromCache()
-    } else {
-      hasLoadedTrades = false
-    }
+    if (outcome === "sync") syncTradesFromCache()
+    else if (outcome === "invalidate") hasLoadedTrades = false
   })
 
   onDestroy(() => {
@@ -972,9 +974,9 @@
   let editingTradeId: string | null = $state(null)
   let tradeEditTitle = $state("")
   let tradeEditInputEl: HTMLInputElement | null = $state(null)
-  let savingTradeId: string | null = null
+  let savingTradeId: string | null = $state(null)
   let draftTrade: BookmarksTradeStruct | null = $state(null)
-  let isCommittingDraft = false
+  let isCommittingDraft = $state(false)
 
   const startEditingTrade = async (trade: BookmarksTradeStruct) => {
     if (!trade.id) return
@@ -1037,7 +1039,7 @@
         folder.id
       )
       cancelDraftTrade()
-      await refreshTrades()
+      syncTradesFromCache()
       flashMessages.success(
         translate($languageStore, "folder.addedToFolder", { title })
       )
@@ -1493,6 +1495,7 @@
                   class:is-drag-over={dragOverIndex === i}
                   role="group"
                   aria-current={isActiveTrade ? "page" : undefined}
+                  aria-busy={savingTradeId === trade.id}
                   aria-label={trade.title}
                   onpointerdown={handleTradeCardPointerDown}
                   onpointerup={(event) => handleTradeCardClick(event, trade)}>
@@ -1528,6 +1531,9 @@
                               title={trade.title}>
                               {trade.title}
                             </span>
+                            {#if savingTradeId === trade.id}
+                              <span class="trade-saving" aria-hidden="true">↻</span>
+                            {/if}
                             {#if trade.archivedAt}
                               <span class="archive-status">{translate($languageStore, "bookmarks.toolbar.archive")}</span>
                             {/if}
@@ -1583,7 +1589,7 @@
           {/each}
           {#if draftTrade}
             <li>
-              <div class="trade-item">
+              <div class="trade-item" aria-busy={isCommittingDraft}>
                 <div class="trade-content">
                   <div class="trade-top">
                     <input
@@ -1592,12 +1598,16 @@
                       aria-label={translate($languageStore, "folder.saveCurrentSearch")}
                       bind:this={tradeEditInputEl}
                       bind:value={tradeEditTitle}
+                      readonly={isCommittingDraft}
                       onblur={handleDraftBlur}
                       onkeydown={(event) => {
                         event.stopPropagation()
                         if (event.key === "Enter") void commitDraftTrade()
                         if (event.key === "Escape") cancelDraftTrade()
                       }} />
+                    {#if isCommittingDraft}
+                      <span class="trade-saving" aria-hidden="true">↻</span>
+                    {/if}
                   </div>
                 </div>
               </div>
@@ -2253,6 +2263,30 @@
   align-items: center;
   gap: 6px;
   min-width: 0;
+}
+
+.trade-saving {
+  flex: 0 0 auto;
+  display: inline-block;
+  color: rgba(205, 180, 137, 0.95);
+  font-size: calc(12px * var(--bt-text-scale, 1));
+  line-height: 1;
+  animation: trade-saving-spin 1s linear infinite;
+}
+
+@keyframes trade-saving-spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .trade-saving {
+    animation: none;
+  }
 }
 
 .archive-status {

--- a/lib/services/bookmark-trade-sync.ts
+++ b/lib/services/bookmark-trade-sync.ts
@@ -1,0 +1,29 @@
+export type TradeSyncOutcome = "sync" | "invalidate" | "ignore"
+
+export type TradeSyncInput = {
+  folderId: string | null | undefined
+  eventFolderId: string | null | undefined
+  tradesChanged: boolean
+  isExpanded: boolean
+  isCommittingDraft: boolean
+}
+
+/**
+ * Picks how a folder reacts to a bookmarks change event.
+ *
+ * Committing a draft yields `ignore`: `persistTrades` notifies before its
+ * awaits, so syncing then would render the stored row next to the still-open
+ * draft input until the write resolves.
+ */
+export const decideTradeSync = ({
+  folderId,
+  eventFolderId,
+  tradesChanged,
+  isExpanded,
+  isCommittingDraft
+}: TradeSyncInput): TradeSyncOutcome => {
+  if (!folderId || !tradesChanged || eventFolderId !== folderId) return "ignore"
+  if (isCommittingDraft) return "ignore"
+
+  return isExpanded ? "sync" : "invalidate"
+}

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "whats-new": "node scripts/generate-whats-new.cjs",
     "data:refresh": "node scripts/refresh-trade-locale-data.mjs && node scripts/refresh-chinese-trade-dictionaries.mjs",
     "trade:fixtures:update": "node scripts/trade-fixtures-update.mjs",
-    "test": "pnpm run test:bookmark-sync && node --no-warnings --experimental-strip-types --test tests/bookmark-export-compatibility.test.mjs tests/legacy-bookmark-search-state.test.mjs tests/bookmark-scroll-restore.test.mjs tests/chinese-trade-text-transform.test.mjs tests/chinese-trade-stat-cache.test.mjs tests/chinese-trade-cache-lifecycle.test.mjs tests/normalize-valdo-reward-name.test.mjs tests/trade-selectors.test.mjs tests/trade-filters.test.mjs tests/trade-dom.test.mjs tests/trade-context.test.mjs tests/feature-lifecycle.test.mjs tests/trade-dom-observer.test.mjs tests/extension-bus.test.mjs",
+    "test": "pnpm run test:bookmark-sync && node --no-warnings --experimental-strip-types --test tests/bookmark-export-compatibility.test.mjs tests/legacy-bookmark-search-state.test.mjs tests/bookmark-scroll-restore.test.mjs tests/bookmark-trade-sync.test.mjs tests/chinese-trade-text-transform.test.mjs tests/chinese-trade-stat-cache.test.mjs tests/chinese-trade-cache-lifecycle.test.mjs tests/normalize-valdo-reward-name.test.mjs tests/trade-selectors.test.mjs tests/trade-filters.test.mjs tests/trade-dom.test.mjs tests/trade-context.test.mjs tests/feature-lifecycle.test.mjs tests/trade-dom-observer.test.mjs tests/extension-bus.test.mjs",
     "test:bookmark-sync": "node scripts/test-bookmark-sync.cjs",
     "test:bookmark-exports": "pnpm test",
     "typecheck": "tsc --noEmit",

--- a/tests/bookmark-trade-sync.test.mjs
+++ b/tests/bookmark-trade-sync.test.mjs
@@ -1,0 +1,57 @@
+// Saving a search stages the row and notifies subscribers before the journal
+// write resolves. Syncing on that notification while the draft input is still
+// open rendered the same search twice until the write finished.
+
+import assert from "node:assert/strict"
+import test from "node:test"
+
+const { decideTradeSync } = await import("../lib/services/bookmark-trade-sync.ts")
+
+const base = {
+  folderId: "folder-1",
+  eventFolderId: "folder-1",
+  tradesChanged: true,
+  isExpanded: true,
+  isCommittingDraft: false
+}
+
+test("holds the sync while a draft is being committed", () => {
+  // Arrange: the notification that persistTrades fires before its awaits.
+  const input = { ...base, isCommittingDraft: true }
+
+  // Act
+  const outcome = decideTradeSync(input)
+
+  // Assert: no sync, so the stored row cannot appear beside the draft input.
+  assert.equal(outcome, "ignore")
+})
+
+test("does not invalidate a collapsed folder mid-commit", () => {
+  const input = { ...base, isExpanded: false, isCommittingDraft: true }
+  assert.equal(decideTradeSync(input), "ignore")
+})
+
+test("syncs an expanded folder once no draft is in flight", () => {
+  assert.equal(decideTradeSync(base), "sync")
+})
+
+test("invalidates a collapsed folder instead of syncing it", () => {
+  assert.equal(decideTradeSync({ ...base, isExpanded: false }), "invalidate")
+})
+
+test("ignores events for another folder", () => {
+  assert.equal(decideTradeSync({ ...base, eventFolderId: "folder-2" }), "ignore")
+})
+
+test("ignores events that did not change trades", () => {
+  assert.equal(decideTradeSync({ ...base, tradesChanged: false }), "ignore")
+})
+
+test("ignores events when the folder has no id yet", () => {
+  assert.equal(decideTradeSync({ ...base, folderId: null, eventFolderId: null }), "ignore")
+  assert.equal(decideTradeSync({ ...base, folderId: undefined }), "ignore")
+})
+
+test("ignores a broadcast with no folder id against a real folder", () => {
+  assert.equal(decideTradeSync({ ...base, eventFolderId: undefined }), "ignore")
+})


### PR DESCRIPTION
## Problem

Saving a search into a folder left the name sitting in an open edit input with
no feedback, and the success message only arrived well after. The wait read as
the save having failed.

Tracing `commitDraftTrade`:

- `persistTrades` stages the row, writes the cache, and calls `notifyChange`
  **before** awaiting `persistJournal` and `requestBackgroundFlush`. The
  dispatch is synchronous, so the folder's `onChange` subscriber ran
  `syncTradesFromCache()` immediately and the stored row was rendered while the
  draft input was still on screen. The same search appeared twice for the
  duration of the write.
- After the write the commit called `await refreshTrades()`, which forces a
  full `fetchTradesByFolderId`, sets `hasLoadedTrades = false` (a loading
  flicker), and adds two more background round-trips for the scroll
  save/restore — all to reproduce a list the notification had already staged.
- `savingTradeId` and `isCommittingDraft` were plain `let`, not `$state`, so
  neither could drive UI in runes mode. Nothing showed that work was in flight.

## Change

- The change subscriber now ignores events while a draft is committing, so the
  stored row cannot appear next to the draft input. That decision moved into
  `decideTradeSync` in `lib/services/bookmark-trade-sync.ts`, kept free of
  component state so it is directly testable.
- `commitDraftTrade` calls `syncTradesFromCache()` instead of
  `refreshTrades()`. The notification already updated the cache, so the forced
  reload was redundant latency.
- Both in-flight flags are `$state`, and the row being written shows a spinner
  and `aria-busy` — for a new search and for a rename.

The remaining wait is the journal write plus the background flush, which is
work the save genuinely has to do before it can report success, so the row
reports it rather than hiding it. The spinner reuses the `↻` glyph and spin
animation already used by `LoadingContainer`, and is dropped under
`prefers-reduced-motion`.

## Testing

- `pnpm typecheck` — clean
- `pnpm test` — 90 passing (82 before, 8 new)
- `pnpm build` — Chrome and Firefox

Against the previous logic 2 of the 8 new cases fail, both asserting that a
change event is ignored while a draft commit is in flight.

I traced the latency from the code path rather than measuring it in a running
profile, so the ordering claims are from the source, not from a trace.

No user-facing strings were added — the indicator is an `aria-hidden` glyph
plus `aria-busy` — so no locale files changed. I left the What's New entry and
the version bump to your release flow.

`updateTradeLocation` still calls `refreshTrades()` in the same redundant
shape. I left it alone since it was outside the reported problem; happy to
follow up if you want it changed.
