### PR TITLE
Release v1.1.34

### DIFF
--- a/lib/data/whats-new.ts
+++ b/lib/data/whats-new.ts
@@ -523,10 +523,26 @@ const version1133Fixes: WhatsNewItem[] = [
   }
 ];
 
+const version1134Fixes: WhatsNewItem[] = [
+  {
+    titleKey: "whatsNew.item.bookmarkSaveProgressTitle",
+    descriptionKey: "whatsNew.item.bookmarkSaveProgressDescription"
+  }
+];
+
 export const latestWhatsNew: WhatsNewEntry = {
-  version: "1.1.33",
+  version: "1.1.34",
   date: "2026-09-06",
   sections: [
+    {
+      title: "1.1.34",
+      groups: [
+        {
+          titleKey: "whatsNew.section.fixes",
+          items: version1134Fixes
+        }
+      ]
+    },
     {
       title: "1.1.33",
       groups: [

--- a/lib/services/i18n/de.ts
+++ b/lib/services/i18n/de.ts
@@ -2,6 +2,8 @@ import { englishTranslations } from "./en"
 import type { TranslationValue } from "./types"
 
 export const germanTranslations: Record<string, TranslationValue> = {
+  "whatsNew.item.bookmarkSaveProgressTitle": "Das Speichern von Lesezeichen zeigt jetzt den Fortschritt",
+  "whatsNew.item.bookmarkSaveProgressDescription": "Beim Speichern oder Umbenennen eines Lesezeichens wird jetzt ein Fortschrittsindikator angezeigt, und die gespeicherte Suche erscheint nicht mehr kurz neben ihrer Entwurfszeile.",
   "whatsNew.item.manualBookmarkScrollTitle": "Manuelles Scrollen von Lesezeichen funktioniert zuverlässig",
   "whatsNew.item.manualBookmarkScrollDescription": "Die gespeicherte Lesezeichenposition wird nur wiederhergestellt, während die Liste lädt. Beim Scrollen mit Maus, Touch, Tastatur oder Zeiger übernimmst du sofort die Kontrolle und die Liste springt nicht mehr zurück.",
   "whatsNew.item.activeBookmarkHighlightTitle": "Das geöffnete Lesezeichen hervorheben",

--- a/lib/services/i18n/en.ts
+++ b/lib/services/i18n/en.ts
@@ -1,6 +1,8 @@
 import type { TranslationValue } from "./types"
 
 export const englishTranslations: Record<string, TranslationValue> = {
+  "whatsNew.item.bookmarkSaveProgressTitle": "Bookmark saves now show their progress",
+  "whatsNew.item.bookmarkSaveProgressDescription": "Saving or renaming a bookmark now shows a progress indicator, and the saved search no longer briefly appears beside its draft row.",
   "whatsNew.item.manualBookmarkScrollTitle": "Manual bookmark scrolling works reliably",
   "whatsNew.item.manualBookmarkScrollDescription": "The saved bookmark position restores only while the list is loading. Scrolling with the mouse, touch, keyboard, or pointer immediately takes over, so the list no longer jumps back.",
   "whatsNew.item.activeBookmarkHighlightTitle": "Highlight the bookmark you have open",

--- a/lib/services/i18n/es.ts
+++ b/lib/services/i18n/es.ts
@@ -1,6 +1,8 @@
 import type { TranslationValue } from "./types"
 
 export const spanishTranslations: Record<string, TranslationValue> = {
+  "whatsNew.item.bookmarkSaveProgressTitle": "Ahora se muestra el progreso al guardar marcadores",
+  "whatsNew.item.bookmarkSaveProgressDescription": "Al guardar o renombrar un marcador ahora se muestra un indicador de progreso, y la búsqueda guardada ya no aparece brevemente junto a su fila de borrador.",
   "whatsNew.item.manualBookmarkScrollTitle": "El desplazamiento manual de marcadores funciona de forma fiable",
   "whatsNew.item.manualBookmarkScrollDescription": "La posición guardada de los marcadores solo se restaura mientras carga la lista. Al desplazarte con el ratón, toque, teclado o puntero, tomas el control de inmediato y la lista deja de volver atrás.",
   "whatsNew.item.activeBookmarkHighlightTitle": "Resalta el marcador que tienes abierto",

--- a/lib/services/i18n/fr.ts
+++ b/lib/services/i18n/fr.ts
@@ -2,6 +2,8 @@ import { englishTranslations } from "./en"
 import type { TranslationValue } from "./types"
 
 export const frenchTranslations: Record<string, TranslationValue> = {
+  "whatsNew.item.bookmarkSaveProgressTitle": "L'enregistrement des favoris affiche désormais sa progression",
+  "whatsNew.item.bookmarkSaveProgressDescription": "Enregistrer ou renommer un favori affiche désormais un indicateur de progression, et la recherche enregistrée n'apparaît plus brièvement à côté de sa ligne de brouillon.",
   "whatsNew.item.manualBookmarkScrollTitle": "Le défilement manuel des favoris fonctionne de manière fiable",
   "whatsNew.item.manualBookmarkScrollDescription": "La position enregistrée des favoris est restaurée uniquement pendant le chargement de la liste. Faire défiler avec la souris, le tactile, le clavier ou le pointeur vous redonne immédiatement le contrôle, et la liste ne revient plus en arrière.",
   "whatsNew.item.activeBookmarkHighlightTitle": "Mettre en évidence le signet que vous avez ouvert",

--- a/lib/services/i18n/ja.ts
+++ b/lib/services/i18n/ja.ts
@@ -2,6 +2,8 @@ import { englishTranslations } from "./en"
 import type { TranslationValue } from "./types"
 
 export const japaneseTranslations: Record<string, TranslationValue> = {
+  "whatsNew.item.bookmarkSaveProgressTitle": "ブックマークの保存進行状況を表示",
+  "whatsNew.item.bookmarkSaveProgressDescription": "ブックマークの保存または名前変更時に進行状況が表示され、保存済みの検索が下書き行の横に一時的に表示されなくなりました。",
   "whatsNew.item.manualBookmarkScrollTitle": "ブックマークの手動スクロールが安定して動作",
   "whatsNew.item.manualBookmarkScrollDescription": "保存されたブックマーク位置は、リストの読み込み中にのみ復元されます。マウス、タッチ、キーボード、またはポインターでスクロールするとすぐに操作が優先され、リストが元の位置へ戻らなくなります。",
   "whatsNew.item.activeBookmarkHighlightTitle": "開いているブックマークを強調表示",

--- a/lib/services/i18n/ko.ts
+++ b/lib/services/i18n/ko.ts
@@ -2,6 +2,8 @@ import { englishTranslations } from "./en"
 import type { TranslationValue } from "./types"
 
 export const koreanTranslations: Record<string, TranslationValue> = {
+  "whatsNew.item.bookmarkSaveProgressTitle": "북마크 저장 진행 상황을 표시합니다",
+  "whatsNew.item.bookmarkSaveProgressDescription": "북마크를 저장하거나 이름을 변경할 때 진행 표시기가 나타나며, 저장된 검색이 초안 행 옆에 잠시 중복 표시되지 않습니다.",
   "whatsNew.item.manualBookmarkScrollTitle": "북마크 수동 스크롤이 안정적으로 작동합니다",
   "whatsNew.item.manualBookmarkScrollDescription": "저장된 북마크 위치는 목록을 불러오는 동안에만 복원됩니다. 마우스, 터치, 키보드 또는 포인터로 스크롤하면 즉시 직접 제어되며 목록이 더 이상 이전 위치로 돌아가지 않습니다.",
   "whatsNew.item.activeBookmarkHighlightTitle": "열려 있는 북마크 강조 표시",

--- a/lib/services/i18n/pt.ts
+++ b/lib/services/i18n/pt.ts
@@ -2,6 +2,8 @@ import { englishTranslations } from "./en"
 import type { TranslationValue } from "./types"
 
 export const portugueseTranslations: Record<string, TranslationValue> = {
+  "whatsNew.item.bookmarkSaveProgressTitle": "Os salvamentos de favoritos agora mostram o progresso",
+  "whatsNew.item.bookmarkSaveProgressDescription": "Salvar ou renomear um favorito agora mostra um indicador de progresso, e a busca salva não aparece mais brevemente ao lado da linha de rascunho.",
   "whatsNew.item.manualBookmarkScrollTitle": "A rolagem manual dos favoritos funciona de forma confiável",
   "whatsNew.item.manualBookmarkScrollDescription": "A posição salva dos favoritos é restaurada apenas enquanto a lista carrega. Ao rolar com o mouse, toque, teclado ou ponteiro, você assume o controle imediatamente e a lista deixa de voltar.",
   "whatsNew.item.activeBookmarkHighlightTitle": "Destaque o marcador que você tem aberto",

--- a/lib/services/i18n/ru.ts
+++ b/lib/services/i18n/ru.ts
@@ -2,6 +2,8 @@ import { englishTranslations } from "./en"
 import type { TranslationValue } from "./types"
 
 export const russianTranslations: Record<string, TranslationValue> = {
+  "whatsNew.item.bookmarkSaveProgressTitle": "Сохранение закладок теперь показывает ход выполнения",
+  "whatsNew.item.bookmarkSaveProgressDescription": "При сохранении или переименовании закладки теперь отображается индикатор выполнения, а сохранённый поиск больше не появляется рядом со строкой черновика.",
   "whatsNew.item.manualBookmarkScrollTitle": "Ручная прокрутка закладок работает надёжно",
   "whatsNew.item.manualBookmarkScrollDescription": "Сохранённая позиция закладок восстанавливается только во время загрузки списка. Прокрутка мышью, касанием, клавиатурой или указателем сразу передаёт управление вам, поэтому список больше не возвращается назад.",
   "whatsNew.item.activeBookmarkHighlightTitle": "Выделение открытой закладки",

--- a/lib/services/i18n/th.ts
+++ b/lib/services/i18n/th.ts
@@ -2,6 +2,8 @@ import { englishTranslations } from "./en"
 import type { TranslationValue } from "./types"
 
 export const thaiTranslations: Record<string, TranslationValue> = {
+  "whatsNew.item.bookmarkSaveProgressTitle": "การบันทึกบุ๊กมาร์กจะแสดงความคืบหน้าแล้ว",
+  "whatsNew.item.bookmarkSaveProgressDescription": "เมื่อบันทึกหรือเปลี่ยนชื่อบุ๊กมาร์ก จะแสดงตัวบ่งชี้ความคืบหน้า และการค้นหาที่บันทึกไว้จะไม่ปรากฏชั่วครู่ข้างแถวฉบับร่างอีกต่อไป",
   "whatsNew.item.manualBookmarkScrollTitle": "การเลื่อนบุ๊กมาร์กด้วยตนเองทำงานได้อย่างเสถียร",
   "whatsNew.item.manualBookmarkScrollDescription": "ตำแหน่งบุ๊กมาร์กที่บันทึกไว้จะถูกกู้คืนเฉพาะขณะที่รายการกำลังโหลดเท่านั้น เมื่อเลื่อนด้วยเมาส์ การสัมผัส แป้นพิมพ์ หรือตัวชี้ คุณจะควบคุมได้ทันทีและรายการจะไม่กระโดดกลับอีกต่อไป",
   "whatsNew.item.activeBookmarkHighlightTitle": "ไฮไลต์บุ๊กมาร์กที่คุณเปิดอยู่",

--- a/lib/services/i18n/zh-cn.ts
+++ b/lib/services/i18n/zh-cn.ts
@@ -2,6 +2,8 @@ import { englishTranslations } from "./en"
 import type { TranslationValue } from "./types"
 
 export const simplifiedChineseTranslations: Record<string, TranslationValue> = {
+  "whatsNew.item.bookmarkSaveProgressTitle": "书签保存现会显示进度",
+  "whatsNew.item.bookmarkSaveProgressDescription": "保存或重命名书签时现在会显示进度指示器，已保存的搜索也不会再短暂地显示在草稿行旁边。",
   "whatsNew.item.manualBookmarkScrollTitle": "手动滚动书签现已稳定可靠",
   "whatsNew.item.manualBookmarkScrollDescription": "保存的书签位置仅会在列表加载时恢复。使用鼠标、触控、键盘或指针滚动会立即由你接管，列表不会再跳回原来的位置。",
   "whatsNew.item.activeBookmarkHighlightTitle": "突出显示当前打开的书签",

--- a/lib/services/i18n/zh-tw.ts
+++ b/lib/services/i18n/zh-tw.ts
@@ -3,6 +3,8 @@ import type { TranslationValue } from "./types"
 
 export const traditionalChineseTranslations: Record<string, TranslationValue> =
   {
+    "whatsNew.item.bookmarkSaveProgressTitle": "儲存書籤時現在會顯示進度",
+    "whatsNew.item.bookmarkSaveProgressDescription": "儲存或重新命名書籤時現在會顯示進度指示器，已儲存的搜尋也不會再短暫顯示在草稿列旁邊。",
     "whatsNew.item.manualBookmarkScrollTitle": "手動捲動書籤現在能穩定運作",
     "whatsNew.item.manualBookmarkScrollDescription": "儲存的書籤位置只會在清單載入時還原。使用滑鼠、觸控、鍵盤或指標捲動時，您會立即接管控制，清單不會再跳回原來的位置。",
     "whatsNew.item.activeBookmarkHighlightTitle": "突顯目前開啟的書籤",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "poe-trade-plus",
   "displayName": "Poe Trade Plus",
-  "version": "1.1.33",
+  "version": "1.1.34",
   "packageManager": "pnpm@11.3.0",
   "engines": {
     "node": ">=22"


### PR DESCRIPTION
# v1.1.34

## 1.1.34
### Fixes
- **Bookmark saves now show their progress** — Saving or renaming a bookmark now shows a progress indicator, and the saved search no longer briefly appears beside its draft row.

## 1.1.33
### Fixes
- **Manual bookmark scrolling works reliably** — The saved bookmark position restores only while the list is loading. Scrolling with the mouse, touch, keyboard, or pointer immediately takes over, so the list no longer jumps back.

## 1.1.32
### Fixes
- **Quick Filters return to the trade page** — Quick Filters now initialize reliably after synced settings load, so the Page placement works on PoE1 and PoE2.

## 1.1.31
### New features
- **Refreshed defaults for a cleaner starting layout** — New installs start with compact bookmark layouts and focused controls. Every option remains available in Settings when you want to customize your workflow.

### Fixes
- **Bookmark sync preserves your order** — Saved-search and folder order now stays consistent across tabs, reloads, and synced devices. Synchronization also recovers safely if a background update is interrupted.

## 1.1.29
### New features
- **Last sync timestamp in Backup & Restore** — The Backup & Restore section now shows the date and time of your most recent sync, so you can confirm your data is up to date at a glance.

## 1.1.28
### New features
- **Highlight the bookmark you have open** — The saved search currently open in the active tab is now highlighted in the bookmark list, making it easy to see which search you are viewing.
- **Bookmark list keeps its place when opening in a new tab** — Opening a saved search in a new background tab preserves the bookmark list scroll position, so you can queue several searches without losing your place.
- **Category titles toggle collapse and expand** — Clicking a category title now collapses or expands that category, matching the arrow button behavior.

### Polish
- **Bookmark toolbar hides earlier** — The bookmark toolbar now hides as soon as you scroll down the list and returns when you scroll back to the top.

## 1.1.27
### New features
- **Swedish interface and localized store listing** — Swedish is now available as an interface language, and Chrome Web Store metadata is included for every language supported by the extension.

## 1.1.26
### New features
- **Custom filter color** — Choose the color used for the selected filter overlay on trade results.

### Fixes
- **Better Trading saved searches stay compatible** — Saved searches copied from Better Trading keep their embedded state when opened.
- **Settings and backups restore reliably** — Your layout, bookmark categories, and preferences are preserved when settings sync or a portable backup is restored.
- **Canceling a new folder leaves no extra folder** — Cancel or press Escape while naming a new bookmark folder to remove it instead of keeping an empty folder.

## 1.1.24
### Fixes
- **Bulk folder opening is temporarily disabled** — Opening every saved search in a folder is temporarily disabled to avoid Path of Exile Trade rate limits. Individual searches can still be opened in a new background tab with middle-click.

## 1.1.23
### Fixes
- **Chinese Trade translation loads reliably** — Translation data now loads only when needed, keeping Chinese Trade activation reliable while reducing the extension's startup size.
- **Sync data recovers from accidental deletion** — The extension keeps a local recovery copy of synced bookmarks and settings, and restores it if browser Sync is unexpectedly emptied.
- **Valdo pricing is hidden on Taiwan Trade** — Valdo reward pricing is no longer shown on pathofexile.tw because poe.ninja does not provide the required prices there.

## 1.1.22
### New features
- **Valdo reward pricing** — Optional PoE1 Valdo map pricing shows the completion reward, its Divine value, and the estimated profit for each listing.

### Fixes
- **Chinese Trade cache recovers reliably** — Chinese Trade data now rebuilds correctly when its local cache expires, is missing, or becomes invalid.

## 1.1.21
### Fixes
- **Fewer browser permissions** — The extension no longer requires Chrome's scripting or unlimited storage permissions. Chinese Trade data now uses a smaller local cache.

## 1.1.20
### New features
- **Chinese trade-site translation** — The extension now includes Traditional and Simplified Chinese, translates the international PoE1 trade site, and supports the Taiwan trade server while searches keep working in Chinese and English.
- **Archive completed bookmarks** — Archive completed saved searches inside their folder, restore them later, and switch between active and archived entries.
- **Gem reference links** — Skill gems now show Wiki links, plus PoeDB links for PoE1.
- **Full release notes on GitHub** — The What's New dialog now links directly to the matching GitHub release.

### Fixes
- **More reliable search history** — History keeps saved-search titles and serializes simultaneous writes so entries no longer overwrite each other.

## 1.1.19
### New features
- **Duplicate bookmarks directly** — Saved-search actions now include Duplicate bookmark, so you can make a copy without recreating the search.

## 1.1.18
### New features
- **Pinned items return** — Reimplemented from the original Better Trading workflow, optional pins keep a result available during the current search and let you jump back to it from the sidebar.

## 1.1.17
### New features
- **Sync bookmarks and settings across devices** — Bookmarks, bookmark folders, and extension settings now follow your signed-in browser profile. Existing data is safely migrated when you update.

## 1.1.16
### Fixes
- **Medium text size works correctly** — Selecting Medium in General settings now keeps your preferred text size after the extension reloads.

## 1.1.14
### New features
- **Middle-click folders to open saved searches** — Middle-click a bookmark folder to open all its saved searches in background tabs.

## 1.1.13
### New features
- **Kakao Games trade site support** — The sidebar and trade helpers now work on poe.kakaogames.com for both PoE1 (/trade) and PoE2 (/trade2).

## 1.1.12
### Fixes
- **Middle-click no longer enables auto-scroll** — Middle-clicking a saved search opens it in a background tab without activating the browser's auto-scroll cursor.

## 1.1.11
### New features
- **Guided tutorial refreshed** — The tutorial now follows the main workflows, groups related settings together, and keeps its guide cards out of the way of the controls they explain.
- **Bookmark Layout preview matches the real list** — The live preview now uses the real folder and bookmark components, including categories, two example searches, and the layout-specific action placement.

## 1.1.10
### New features
- **Open saved searches in new tabs** — Middle-click a saved search to open it in a background tab, so you can queue several searches without leaving the current one.
- **Bookmark icons are easier to browse** — The folder icon picker now groups currency and ascendancy icons, making the right icon faster to find.
- **Sidebar preferences are more reliable** — Sidebar defaults are shared consistently, and the Path of Building copy action remains visible where it is available on PoE2.

## 1.1.9
### Fixes
- **Bookmarks update more reliably** — Saved bookmark changes now validate stored data before updating the sidebar, preventing malformed or outdated storage entries from causing problems.
- **Cleaner Bookmark Layout preview** — The live Bookmark Layout preview no longer shows a league label, keeping the sample focused on the layout and actions.

## 1.1.8
### New features
- **Optional desecrated mods in Craft of Exile exports** — Craft of Exile exports now exclude desecrated mods by default. You can opt in from Results settings to include them as normal modifiers, with a warning that Craft of Exile does not yet support importing them.

## 1.1.7
### New features
- **Bookmarks follow active trade realm** — Saved searches now open in the active trade tab's current league and realm, while keeping their saved league as a fallback.
- **Clear Buyout Price shortcut** — Quick Filter Presets now include a Clear button that resets Buyout Price to Chaos Orb Equivalent and works with supported trade-site languages.

## 1.1.6
### New features
- **Wiki button for unique items** — Results can now show an optional W action on unique items that opens the matching PoE Wiki or PoE2 Wiki page.
- **Minimal bookmark layout** — Bookmarks now offer Classic, Compact, and Minimal layouts. Minimal keeps rows dense without changing the Path of Exile look.
- **Actions saved per layout** — Choose visible bookmark actions independently for Classic, Compact, and Minimal. Settings and preview update together.

## 1.1.5
### New features
- **Bookmark categories inside folders** — Saved searches can now be grouped into optional categories inside each bookmark folder. The feature is off by default, and turning it off returns every bookmark to the main folder list.
- **Cleaner bookmark action menus** — Category assignment, category creation, and category deletion now live inside the bookmark action menu, with inline creation and the same delete confirmation modal used elsewhere.

### Polish
- **Settings are more compact** — Long setting descriptions now appear as hover help, reducing visual clutter while keeping the details available when you need them.
- **General settings are clearer** — The Interface tab is now General, and Backup & Restore lives there alongside the other extension-wide options.

## 1.1.4
### New features
- **Adjustable text size** — Interface settings now include Small, Medium, Large, and Extra text sizes, with Large as the default.
- **Tutorial access moved to About** — The button to reopen the onboarding tutorial now lives in About, keeping Interface settings focused on display and language options.

## 1.1.3
### New features
- **Full extension backup** — Backup files now include saved folders, searches, global settings, PoE1/PoE2 result settings, and extension preferences in one portable JSON file.
- **Old folder backups still restore** — The restore action still accepts older folder-only .txt exports, so existing backups remain usable.

## 1.1.2
### New features
- **External reference links in the popup** — The popup can now show grouped PoE1 and PoE2 shortcuts for the official trade-adjacent tools, including the Path of Exile Wiki, Path of Exile 2 Wiki, Path of Regex, Craft of Exile, PoEDb, PoE2Db, and poe.ninja.
- **New PoE2 bookmark folder icons** — Disciple of Varashta, Martial Artist, and Spirit Walker icons are available for PoE2 bookmark folders.
- **Mageblood Legacy descriptions for PoE2** — A new Results setting can show hidden Mageblood Legacy effects below PoE2 item results, including duplicate Legacy scaling.

### Fixes
- **Localized PoE2 trade links load correctly** — Bookmarks and helper panels now recognize localized trade2 hosts such as es.pathofexile.com and keep league URLs with spaces encoded correctly.
- **Mageblood Legacy works across languages** — Legacy detection now uses stable trade stat ids, with localized effect descriptions for English, Spanish, Portuguese, Russian, Thai, German, French, Japanese, and Korean.

### Polish
- **Mageblood details stay quiet until hover** — Legacy descriptions show the final value by default, while base value and duplicate effect details appear inline on hover.
- **Mageblood descriptions match item layout** — Legacy description blocks now sit below corrupt/explicit separators like native notable descriptions and stay out of copied item text.

## 1.1.1
### Fixes
- **Foulborn items add the correct modifier** — Quick filter buttons now compensate for mutated Foulborn item rows where the trade site shifts modifier stat ids out of visual order.
- **Bookmark action buttons no longer open searches** — Editing, refreshing, duplicating, or opening the bookmark menu stays inside that action instead of triggering the saved search row.
- **PoE2 copy stays out of PoE1** — The Path of Building copy option is now only shown on the PoE2 trade site.
- **Craft of Exile buttons keep their shape** — The CoE action button is now a centered 30px square so it aligns cleanly with the result row controls.

### Polish
- **Craft of Exile copy avoids unsupported modifier slots** — Items with Prefix/Suffix Modifier allowed affixes now show a greyed CoE button with an explanation, while Copy for PoB keeps working.
- **Version-specific settings are clearer** — PoE1 and PoE2 can keep separate result-tool preferences where that matters, and PoE2-only tools stay hidden on PoE1.

## 1.1.0
### New features
- **Settings are now easier to navigate** — Customization is grouped into Interface, Sidebar, Results, and Bookmarks so each option has a clearer home.
- **Bookmark Layout now has a live preview** — The Bookmarks settings tab shows a real-time saved-search preview using the same action menu as the actual bookmark list.
- **What's New is now built into the sidebar** — New releases can show a compact update prompt, plus a full release notes modal from About.
- **Quick Filter Presets can live where you work** — Enable them from Results settings, then choose whether they appear in the sidebar or directly above the trade site's Stat Filters.
- **Craft of Exile export is easier to reach** — PoE1 and PoE2 result rows can now expose a CoE action that copies items in Craft of Exile's advanced import format.
- **PoE2 copy support for Path of Building** — A dedicated PoE2 copy option can surface beside other result actions and copy item text ready for PoB.
- **Equivalent pricing works across both games** — poe.ninja ratios now support PoE1 and PoE2 so chaos/divine conversion stays useful on either trade site.

### Polish
- **Sidebar and result options were separated** — Visible sidebar modules now live under Sidebar, while injected trade-result tools stay under Results.
- **Add To Filters moved out of the sidebar by default** — Quick filter presets can now be injected into the trade page, keeping the sidebar focused on navigation and saved searches.
- **Bookmark folders remember their open state** — Expanded and collapsed folders persist more predictably across sessions.
- **History labels and trade URLs are cleaner** — League names, fallbacks, and trade-link handling received small consistency improvements.
- **Result cards are easier to use** — Card click handling and seller panel accessibility were tightened for repeated trade workflows.

### Fixes
- **More reliable background messaging** — Background requests and bulk seller caching now handle failure cases more defensively.
- **Finer Filters hover behavior is smoother** — Compact result layouts and item filter buttons now behave more consistently.
- **Bookmark text opens saved searches again** — Clicking the saved-search title now opens the bookmark instead of being ignored.
- **Extension dependencies were hardened** — Dependency overrides and validation changes reduce known package and request risks.
